### PR TITLE
Do not run test requiring root when fakeroot is used

### DIFF
--- a/tests/kern/runtest
+++ b/tests/kern/runtest
@@ -17,6 +17,11 @@ if [ -z "$PATH_DIOD" ]; then
     exit 1
 fi
 
+if test -n "$FAKEROOTKEY"; then
+    echo "using fakeroot - skipping" >$TEST.out
+    exit 77
+fi
+
 if test $(id -u) != 0; then
     echo "not root - skipping" >$TEST.out
     exit 77

--- a/tests/misc/t00
+++ b/tests/misc/t00
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 TEST=$(basename $0 | cut -d- -f1)
+test -n "$FAKEROOTKEY" && exit 77 #skip if under fakeroot
 test $(id -u) == 0 || exit 77 #skip if not root
 ./tsetfsuid >$TEST.out 2>&1
 diff $TEST.exp $TEST.out >$TEST.diff

--- a/tests/misc/t01
+++ b/tests/misc/t01
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 TEST=$(basename $0 | cut -d- -f1)
+test -n "$FAKEROOTKEY" && exit 77 #skip if under fakeroot
 test $(id -u) == 0 || exit 77 #skip if not root
 ./tsetfsuidsupp >$TEST.out 2>&1
 diff $TEST.exp $TEST.out >$TEST.diff

--- a/tests/misc/t02
+++ b/tests/misc/t02
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 TEST=$(basename $0 | cut -d- -f1)
+test -n "$FAKEROOTKEY" && exit 77 #skip if under fakeroot
 test $(id -u) == 0 || exit 77 #skip if not root
 ./tsuppgrp >$TEST.out 2>&1
 diff $TEST.exp $TEST.out >$TEST.diff

--- a/tests/misc/t03
+++ b/tests/misc/t03
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 TEST=$(basename $0 | cut -d- -f1)
+test -n "$FAKEROOTKEY" && exit 77 #skip if under fakeroot
 test $(id -u) == 0 || exit 77 #skip if not root
 ./tsetuid >$TEST.out 2>&1
 diff $TEST.exp $TEST.out >$TEST.diff

--- a/tests/misc/t11
+++ b/tests/misc/t11
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 TEST=$(basename $0 | cut -d- -f1)
+test -n "$FAKEROOTKEY" && exit 77 #skip if under fakeroot
 test $(id -u) == 0 || exit 77 #skip if not root
 ./tcap >$TEST.out 2>&1
 diff $TEST.exp $TEST.out >$TEST.diff

--- a/tests/user/runtest
+++ b/tests/user/runtest
@@ -22,6 +22,10 @@ case $(basename $TEST) in
         fi
         ;;
     t11|t13|t14)
+        if [ -n "$FAKEROOTEKEY" ]; then
+            echo "cannot use fakeroot" >$TEST.out
+            exit 77
+        fi
         if [ $(id -u) != 0 ]; then
             echo "requires root" >$TEST.out
             exit 77


### PR DESCRIPTION
When build process is run under fakeroot reported UID is 0, but
it is not enough to run tests requiring root access. Using
fakeroot is needed for example for building Debian package.

I'm using a similar patch in Debian package. It would be good to drop it.
