### PR TITLE
Add noreturn attribute to various *_exit functions

### DIFF
--- a/libdiod/diod_log.h
+++ b/libdiod/diod_log.h
@@ -28,15 +28,15 @@ char *diod_log_get_dest (void);
 void diod_log_msg (const char *fmt, va_list ap);
 
 void err_exit (const char *fmt, ...)
-        __attribute__ ((format (printf, 1, 2)));
+        __attribute__ ((format (printf, 1, 2), noreturn));
 void err (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 void errn_exit (int errnum, const char *fmt, ...)
-        __attribute__ ((format (printf, 2, 3)));
+        __attribute__ ((format (printf, 2, 3), noreturn));
 void errn (int errnum, const char *fmt, ...)
         __attribute__ ((format (printf, 2, 3)));
 void msg_exit (const char *fmt, ...)
-        __attribute__ ((format (printf, 1, 2)));
+        __attribute__ ((format (printf, 1, 2), noreturn));
 void msg (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 


### PR DESCRIPTION
This make report generated by llvm static analyzer much more usefull.

After applying this patch and running the analyzer:

   scan-build ./configure
   scan-build -v -V make

There are 4 reports. One is dead assignment (harmless, utils/dtop.c:646), two null pointer deferences in assert statements (liblsd/list.c:684, 719, with complex conditions) and another error in libnpfs/np.c:157 (here if s is 0 and   buf_check_size(buf, 2+slen) is true memmove() gets a null argument.
