### PR TITLE
Add proto.h to BUILT_SOURCES and nodist_SOURCES

### DIFF
--- a/tests/kern/dbench/Makefile.am
+++ b/tests/kern/dbench/Makefile.am
@@ -17,6 +17,11 @@ dbench_SOURCES = \
 	snprintf.c \
 	dbench.h
 
+dbench_nodist_SOURCES = \
+	proto.h
+
+BUILT_SOURCES = proto.h
+
 CLEANFILES = proto.h
 
 proto.h: $(dbench_SOURCES) mkproto.pl


### PR DESCRIPTION
This fixes 'make check' in clean source tree. Otherwise it fails in tests/kern/dbench if proto.h does not already exist.
