### PR TITLE
init: add systemd service for diod

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,7 @@ AC_CONFIG_FILES( \
   scripts/Makefile \
   scripts/diod.init \
   scripts/auto.diod \
+  scripts/diod.service \
   diod/Makefile \
   utils/Makefile \
   tests/Makefile \

--- a/diod.spec.in
+++ b/diod.spec.in
@@ -48,12 +48,12 @@ mv $RPM_BUILD_ROOT%{_mandir}/man8/diodmount.8 \
 rm -rf ${RPM_BUILD_ROOT}
 
 %post
-if [ -x /sbin/chkconfig ]; then /sbin/chkconfig --add diod; fi
+/usr/bin/systemctl enable diod
 
 %preun
 if [ "$1" = 0 ]; then
-  %{_sysconfdir}/init.d/diod stop >/dev/null 2>&1 || :
-  if [ -x /sbin/chkconfig ]; then /sbin/chkconfig --del diod; fi
+  /usr/bin/systemctl stop diod
+  /usr/bin/systemctl disable diod
 fi
 
 %files
@@ -63,6 +63,6 @@ fi
 /sbin/*
 %{_mandir}/man8/*
 %{_mandir}/man5/*
-%attr(0755,root,root) %{_sysconfdir}/init.d/diod
+%attr(0755,root,root) %{_sysconfdir}/systemd/system/diod.service
 %config(noreplace) %attr(0755,root,root) %{_sysconfdir}/auto.diod
 %config(noreplace) %attr(0644,root,root) %{_sysconfdir}/diod.conf

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,11 +1,13 @@
+systemddir=$(sysconfdir)/systemd/system
+
 install-data-local:
-	$(top_srcdir)/config/install-sh -m 755 $(srcdir)/diod.init \
-		$(DESTDIR)$(sysconfdir)/init.d/diod
 	$(top_srcdir)/config/install-sh -m 755 $(srcdir)/auto.diod \
 		$(DESTDIR)$(sysconfdir)/auto.diod
+	$(top_srcdir)/config/install-sh -m 755 $(srcdir)/diod.service \
+		$(DESTDIR)$(systemddir)/diod.service
 
 uninstall-local:
-	$(RM) $(DESTDIR)$(sysconfdir)/init.d/diod
 	$(RM) $(DESTDIR)$(sysconfdir)/auto.diod
+	$(RM) $(DESTDIR)$(systemddir)/diod.service
 
-EXTRA_DIST = diod.init auto.diod
+EXTRA_DIST = diod.init auto.diod diod.service

--- a/scripts/diod.service.in
+++ b/scripts/diod.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=9P File Server
+
+[Service]
+Type=forking
+ExecStart=@X_SBINDIR@/diod
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Disable the sysv init script and enable this instead.

Fixes issue #11