### PR TITLE
use <sys/xattr.h> rather than <attr/xattr.h>

### DIFF
--- a/diod/xattr.c
+++ b/diod/xattr.c
@@ -39,7 +39,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/file.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
 #include <sys/socket.h>


### PR DESCRIPTION
This is a bit tentative, since I don't have a Red Hat system to compare right now:

On my Debian system, <attr/xattr.h> doesn't exist. <sys/xattr.h> does, and provides the right prototypes for xattr.c to use, apparently, so this tiny change makes things compile on an up-to-date sid system.

Mostly, though, this is a success report: with a few trivial changes (to work around the constrained environment of the Debian initrd), I'm able to boot a diskless IPv6-only virtual machine with its (post-initrd) root file system served by diod!