### PR TITLE
don't try to update /etc/mtab unless it is a regular file.

### DIFF
--- a/utils/diodmount.c
+++ b/utils/diodmount.c
@@ -481,7 +481,20 @@ _update_mtab (char *options, char *spec, char *dir)
     uid_t saved_euid = geteuid ();
     FILE *f;
     int ret = 0;
+    struct stat st;
     struct mntent mnt;
+
+    ret = lstat(_PATH_MOUNTED, &st);
+
+    /* /etc/mtab can be a symlink to /proc/mounts or
+     * /proc/self/mounts, in which case we shouldn't write to it even
+     * if /proc isn't mounted.  Return success in that case to avoid a
+     * spurious error message. */
+    if (ret != 0)
+	return 0;
+
+    if (!S_ISREG(st.st_mode))
+	return 1;
 
     mnt.mnt_fsname = spec;
     mnt.mnt_dir = dir;


### PR DESCRIPTION
That's what the other mount helpers appear to be doing.

Debian switched to keeping a symlink to /proc/mounts in /etc/mtab, but didn't modify setmntent(3) to handle that case gracefully, so the only way to avoid error messages on Debian systems appears to be to lstat() /etc/mtab and check it's not a symbolic link.

libmount goes further and keeps some mount data in /run/mount/utab or $LIBMOUNT_UTAB, but I don't think we need to do that.