### PR TITLE
exporting through symlinks/stat vs lstat in diod_walk()

### DIFF
--- a/diod/ops.c
+++ b/diod/ops.c
@@ -426,7 +426,7 @@ diod_walk (Npfid *fid, Npstr* wname, Npqid *wqid)
         np_uerror (errno);
         goto error_quiet;
     }
-    if (lstat (path_s (f->path), &sb2) < 0) {
+    if (stat (path_s (f->path), &sb2) < 0) {
         np_uerror (errno);
         goto error;
     }


### PR DESCRIPTION
Hi,
this (single-character) change fixes a problem for me when exporting through a symlink to a directory on a different file system. If "link" is such a symlink, lstat("link") and lstat("link/file") will have different device ids; that makes diod_walk call _statmnt("link/file"), which tries to stat("link/file/.."), which fails with ENOTDIR:

```
[pid 27405] lstat("/srv/nfs/git/initramfs-tools_0.120_amd64.changes", {st_mode=S_IFREG|0644, st_size=1713, ...}) = 0
[pid 27405] lstat("/srv/nfs/git", {st_mode=S_IFLNK|0777, st_size=13, ...}) = 0
[pid 27405] stat("/srv/nfs/git/initramfs-tools_0.120_amd64.changes", {st_mode=S_IFREG|0644, st_size=1713, ...}) = 0
[pid 27405] stat("/srv/nfs/git/initramfs-tools_0.120_amd64.changes/..", 0x7f13c4fe8a40) = -1 ENOTDIR (Not a directory)
```

I believe the correct thing to do is to stat(f->path), which follows the symlink and returns the same device as lstat(npath) if the latter is a file residing in f.