### PR TITLE
Build fixing patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,24 @@
 `diod` is a multi-threaded, user space file server that speaks
 [9P2000.L protocol](protocol.md).
 
-### Building on Debian 
+### Building
 
+#### On Debian
 ```
-sudo apt-get install liblua5.1-dev libmunge-dev libwrap0-dev libcap-dev
-./configure CPPFLAGS="-I/usr/include/lua5.1" --with-lua-suffix=5.1
+sudo apt-get install build-essential libpopt-dev ncurses-dev automake autoconf
+sudo apt-get install liblua5.1-dev libmunge-dev libwrap0-dev libcap-dev libattr1-dev
+./autogen.sh
+./configure
 make
 make check
 ```
 
-### Building on Red Hat
+#### On Red Hat
 
 ```
-sudo yum install epel-release
+sudo yum install epel-release gperftools-devel automake autoconf libattr-devel
 sudo yum install lua-devel munge-devel tcp_wrappers-devel libcap-devel
-sudo yum install gperftools-devel
+./autogen.sh
 ./configure
 make
 make check

--- a/config/ax_lua.m4
+++ b/config/ax_lua.m4
@@ -164,7 +164,7 @@ AC_DEFUN([AX_LUA_LIBS],
   AC_CHECK_LIB([m], [exp], [lua_extra_libs="$lua_extra_libs -lm"], [])
   AC_CHECK_LIB([dl], [dlopen], [lua_extra_libs="$lua_extra_libs -ldl"], [])
   AC_CHECK_LIB([lua$with_lua_suffix],
-    [lua_call],
+    [luaL_newstate],
     [LIBLUA="$LUA_LIB -llua$with_lua_suffix $lua_extra_libs"],
     [],
     [$LIBLUA $lua_extra_libs])

--- a/libdiod/diod_conf.c
+++ b/libdiod/diod_conf.c
@@ -629,7 +629,7 @@ diod_conf_init_config_file (char *path) /* FIXME: ENOMEM is fatal */
             path = config.configpath;  /* missing default file is not fatal */
     }
     if (path) {
-    	lua_State *L = lua_open ();
+        lua_State *L = luaL_newstate ();
 
         luaopen_base (L);
         luaopen_table (L);

--- a/libdiod/diod_log.h
+++ b/libdiod/diod_log.h
@@ -1,3 +1,5 @@
+#include <stdarg.h>
+
 void diod_log_init (char *p);
 void diod_log_fini (void);
 void diod_log_set_dest (char *dest);

--- a/libnpfs/npfs.h
+++ b/libnpfs/npfs.h
@@ -22,6 +22,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <stdarg.h>
 #include <sys/types.h>
 
 typedef struct p9_str Npstr;

--- a/tests/kern/dbench/Makefile.am
+++ b/tests/kern/dbench/Makefile.am
@@ -25,6 +25,6 @@ BUILT_SOURCES = proto.h
 CLEANFILES = proto.h
 
 proto.h: $(dbench_SOURCES) mkproto.pl
-	./mkproto.pl $(dbench_SOURCES) > proto.h
+	perl mkproto.pl $(dbench_SOURCES) > proto.h
 
 EXTRA_DIST = mkproto.pl


### PR DESCRIPTION
Hi,

These patches solve some compilation issues which the Diod 9p server currently has:
* Eliminating an error when trying to cross-compile a static diod binary. Cross-compiling a statically linked binary may be very useful for embedded or minimalist systems.
* If the Perl binary was not in /usr/bin/perl, the build would fail.
* The build would also fail if Lua 5.2 (and not 5.1) was installed. Deprecated Lua functions replaced.
* Building instructions in README.md were updated.