### PR TITLE
FreeBSD port

### DIFF
--- a/diod/Makefile.am
+++ b/diod/Makefile.am
@@ -24,7 +24,8 @@ diod_SOURCES = \
 	fid.c \
 	fid.h \
 	xattr.c \
-	xattr.h
+	xattr.h \
+	diod_dir.h
 
 man8_MANS = \
         diod.8

--- a/diod/diod.c
+++ b/diod/diod.c
@@ -46,7 +46,9 @@
 #include <sys/stat.h>
 #include <sys/param.h>
 #include <sys/resource.h>
+#ifndef __FreeBSD__
 #include <sys/prctl.h>
+#endif
 #include <string.h>
 #include <signal.h>
 #include <pthread.h>
@@ -323,9 +325,10 @@ _setrlimit (void)
             err_exit ("setrlimit RLIMIT_NOFILE");
 
     r.rlim_cur = r.rlim_max = RLIM_INFINITY;
+#ifndef __FreeBSD__
     if (setrlimit (RLIMIT_LOCKS, &r) < 0)
         err_exit ("setrlimit RLIMIT_LOCKS");
-
+#endif
     r.rlim_cur = r.rlim_max = RLIM_INFINITY;
     if (setrlimit (RLIMIT_CORE, &r) < 0)
         err_exit ("setrlimit RLIMIT_CORE");
@@ -399,6 +402,7 @@ _sighand (int sig)
             break;
     }
 }
+
 
 /* Thread to handle SIGHUP, SIGTERM, and new connections on listen ports.
  */
@@ -619,8 +623,10 @@ _service_run (srvmode_t mode, int rfdno, int wfdno)
      * Set it here, then maintain it in user.c::np_setfsid () as uids are
      * further manipulated.
      */
+#ifndef __FreeBSD__
     if (prctl (PR_SET_DUMPABLE, 1, 0, 0, 0) < 0)
         err_exit ("prctl PR_SET_DUMPABLE failed");
+#endif
 
     if (!diod_conf_get_userdb ())
         flags |= SRV_FLAGS_NOUSERDB;

--- a/diod/diod_dir.h
+++ b/diod/diod_dir.h
@@ -1,0 +1,12 @@
+#ifndef INC_DIOD_DIRENT
+#define INC_DIOD_DIRENT
+
+#include <dirent.h>
+
+struct diod_dirent
+{
+  struct dirent dir_entry;
+  /* for when ! _DIRENT_HAVE_D_OFF */
+  off_t d_off;
+};
+#endif

--- a/diod/fid.c
+++ b/diod/fid.c
@@ -36,10 +36,8 @@
 #include <sys/types.h>
 #include <sys/file.h>
 #include <sys/stat.h>
-#include <sys/statfs.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/fsuid.h>
 #include <sys/mman.h>
 #include <pwd.h>
 #include <grp.h>

--- a/diod/ioctx.h
+++ b/diod/ioctx.h
@@ -1,3 +1,5 @@
+#include "diod_dir.h"
+
 typedef struct path_struct *Path;
 typedef struct ioctx_struct *IOCtx;
 
@@ -14,8 +16,8 @@ int     ioctx_open (Npfid *fid, u32 flags, u32 mode);
 int     ioctx_close (Npfid *fid, int seterrno);
 int     ioctx_pread (IOCtx ioctx, void *buf, size_t count, off_t offset);
 int     ioctx_pwrite (IOCtx ioctx, const void *buf, size_t count, off_t offset);
-int     ioctx_readdir_r(IOCtx ioctx, struct dirent *entry,
-                        struct dirent **result);
+int     ioctx_readdir_r(IOCtx ioctx, struct diod_dirent *entry,
+                        struct diod_dirent **result);
 void    ioctx_rewinddir (IOCtx ioctx);
 void    ioctx_seekdir (IOCtx ioctx, long offset);
 int     ioctx_fsync (IOCtx ioctx);

--- a/diod/xattr.c
+++ b/diod/xattr.c
@@ -39,12 +39,15 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/file.h>
-#include <attr/xattr.h>
-#include <sys/stat.h>
+#ifndef __FreeBSD__
+#include <sys/xattr.h>
 #include <sys/statfs.h>
+#include <sys/fsuid.h>
+#endif
+#include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/fsuid.h>
+
 #include <pwd.h>
 #include <grp.h>
 #include <dirent.h>
@@ -157,6 +160,9 @@ xattr_pread (Xattr x, void *buf, size_t count, off_t offset)
 static int
 _lgetxattr (Xattr x, const char *path)
 {
+#ifdef __FreeBSD__
+  return 0;
+#else
     ssize_t len;
 
     if (x->name)
@@ -182,6 +188,7 @@ _lgetxattr (Xattr x, const char *path)
         return -1; 
     }
     return 0;
+#endif
 }
 
 int
@@ -219,6 +226,9 @@ error:
 int
 xattr_close (Npfid *fid)
 {
+#ifdef __FreeBSD__
+  return 0;
+#else
     Fid *f = fid->aux;
     int rc = 0;
 
@@ -240,6 +250,7 @@ xattr_close (Npfid *fid)
         _xattr_destroy (&f->xattr);
     }
     return rc;
+#endif
 }
 
 

--- a/libdiod/diod_auth.c
+++ b/libdiod/diod_auth.c
@@ -49,7 +49,6 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include <unistd.h>
-#include <sys/fsuid.h>
 #include <string.h>
 #include <pwd.h>
 #include <grp.h>

--- a/libdiod/diod_sock.c
+++ b/libdiod/diod_sock.c
@@ -102,19 +102,19 @@ _enable_keepalive(int fd)
         goto done;
     }
     i = 120;
-    ret = setsockopt (fd, SOL_TCP, TCP_KEEPIDLE, &i, len);
+    ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, &i, len);
     if (ret < 0) {
         err ("setsockopt SO_KEEPIDLE");
         goto done;
     }
     i = 120;
-    ret = setsockopt (fd, SOL_TCP, TCP_KEEPINTVL, &i, len);
+    ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, &i, len);
     if (ret < 0) {
         err ("setsockopt SO_KEEPINTVL");
         goto done;
     }
     i = 9;
-    ret = setsockopt (fd, SOL_TCP, TCP_KEEPCNT, &i, len);
+    ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPCNT, &i, len);
     if (ret < 0) {
         err ("setsockopt SO_KEEPCNT");
         goto done;

--- a/libnpclient/readdir.c
+++ b/libnpclient/readdir.c
@@ -132,7 +132,9 @@ npc_readdir_r (Npcfid *fid, struct dirent *entry, struct dirent **result)
 				       fid->buf_len   - fid->buf_used);
 	if (res == 0)
 		return EIO;
+#ifdef _DIRENT_HAVE_D_OFF
 	entry->d_off = offset;
+#endif
 	entry->d_type = type;
 	entry->d_ino = qid.path;
 	//entry->d_reclen

--- a/libnpfs/fcall.c
+++ b/libnpfs/fcall.c
@@ -1243,7 +1243,12 @@ np_renameat (Npreq *req, Npfcall *tc)
 	if (np_setfsid (req, newdirfid->user, -1) < 0)
 		goto done;
 	if (!req->conn->srv->renameat) {
+#ifdef __FreeBSD__
+	  /* hardcoded linux errno for EOPNOTSUPP */
+		np_uerror (95); /* v9fs expects this not ENOSYS for this op */
+#else
 		np_uerror (EOPNOTSUPP); /* v9fs expects this not ENOSYS for this op */
+#endif
 		goto done;
 	}
 	rc = (*req->conn->srv->renameat)(olddirfid, &tc->u.trenameat.oldname,
@@ -1276,7 +1281,12 @@ np_unlinkat (Npreq *req, Npfcall *tc)
 	if (np_setfsid (req, dirfid->user, -1) < 0)
 		goto done;
 	if (!req->conn->srv->unlinkat) {
+#ifdef __FreeBSD__
+	  /* hardcoded linux errno for EOPNOTSUPP */
+		np_uerror (95); /* v9fs expects this not ENOSYS for this op */
+#else
 		np_uerror (EOPNOTSUPP); /* v9fs expects this not ENOSYS for this op */
+#endif
 		goto done;
 	}
 	rc = (*req->conn->srv->unlinkat)(dirfid, &tc->u.tunlinkat.name);

--- a/libnpfs/user.c
+++ b/libnpfs/user.c
@@ -34,13 +34,17 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/syscall.h>
+#ifndef __FreeBSD__
 #include <sys/fsuid.h>
+#endif
 #include <pwd.h>
 #include <grp.h>
 #if HAVE_LIBCAP
 #include <sys/capability.h>
 #endif
+#ifndef __FreeBSD__
 #include <sys/prctl.h>
+#endif
 
 #include "9p.h"
 #include "npfs.h"
@@ -574,6 +578,9 @@ done:
 int
 np_setfsid (Npreq *req, Npuser *u, u32 gid_override)
 {
+#if __FreeBSD__
+	return 0;
+#else
 	Npwthread *wt = req->wthread;
 	Npsrv *srv = req->conn->srv;
 	int i, n, ret = -1;
@@ -684,4 +691,5 @@ done:
 	if (dumpclrd && prctl (PR_SET_DUMPABLE, 1, 0, 0, 0) < 0)
         	np_logerr (srv, "prctl PR_SET_DUMPABLE failed");
 	return ret;
+#endif
 }


### PR DESCRIPTION
- deal with lack of dirent.d_off on FreeBSD
- make xattr* functions essentially no-ops
- skip prctl() and setrlimit()
- some differences in struct statfs
- some mount options lacking
- replace SOL_TCP by IPPROTO_TCP
- use linux value for errno EOPNOTSUPP