### PR TITLE
compile with CYGWIN

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,7 @@ AX_LUA_HEADERS(501)
 AX_LUA_LIBS
 X_AC_RDMATRANS
 
+
 ##
 # For list.c, hostlist.c, hash.c
 ##
@@ -81,6 +82,8 @@ AC_DEFINE(WITH_LSD_NOMEM_ERROR_FUNC, 1, [Define lsd_nomem_error])
 AC_DEFINE(WITH_PTHREADS, 1, [Make liblsd thread safe])
 
 AC_SYS_LARGEFILE
+
+AM_CONDITIONAL(BUILD_OS_IS_CYGWIN, [test "$build_os" = cygwin])
 
 ##
 # Epilogue

--- a/diod/ops.c
+++ b/diod/ops.c
@@ -74,6 +74,7 @@
 #include <pthread.h>
 #include <errno.h>
 #include <sys/types.h>
+#include <sys/vfs.h>
 
 #ifdef __FreeBSD__
 #if !__BSD_VISIBLE
@@ -614,6 +615,8 @@ diod_statfs (Npfid *fid)
 
 #ifdef __FreeBSD__
     fsid = (u64)sb.f_fsid.val[0] | ((u64)sb.f_fsid.val[1] << 32);
+#elif __CYGWIN__
+    fsid = (u64)sb.f_fsid;
 #else
     fsid = (u64)sb.f_fsid.__val[0] | ((u64)sb.f_fsid.__val[1] << 32);
 #endif
@@ -669,12 +672,16 @@ _remap_oflags (int flags)
         { FASYNC,       P9_DOTL_FASYNC },
         { O_DIRECT,     P9_DOTL_DIRECT },
 #ifndef __FreeBSD__
+#ifndef __CYGWIN__
         { O_LARGEFILE,  P9_DOTL_LARGEFILE },
+#endif
 #endif
         { O_DIRECTORY,  P9_DOTL_DIRECTORY },
         { O_NOFOLLOW,   P9_DOTL_NOFOLLOW },
 #ifndef __FreeBSD__
+#ifndef __CYGWIN__
         { O_NOATIME,    P9_DOTL_NOATIME },
+#endif
 #endif
         { O_CLOEXEC,    P9_DOTL_CLOEXEC },
         { O_SYNC,       P9_DOTL_SYNC},

--- a/diod/xattr.c
+++ b/diod/xattr.c
@@ -42,7 +42,9 @@
 #ifndef __FreeBSD__
 #include <sys/xattr.h>
 #include <sys/statfs.h>
+#ifndef __CYGWIN__
 #include <sys/fsuid.h>
+#endif
 #endif
 #include <sys/stat.h>
 #include <sys/socket.h>

--- a/libdiod/diod_sock.c
+++ b/libdiod/diod_sock.c
@@ -101,24 +101,30 @@ _enable_keepalive(int fd)
         err ("setsockopt SO_KEEPALIVE");
         goto done;
     }
+#ifdef TCP_KEEPIDLE
     i = 120;
     ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, &i, len);
     if (ret < 0) {
         err ("setsockopt SO_KEEPIDLE");
         goto done;
     }
+#endif
+#ifdef TCP_KEEPIINTVL
     i = 120;
     ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, &i, len);
     if (ret < 0) {
         err ("setsockopt SO_KEEPINTVL");
         goto done;
     }
+#endif
+#ifdef TCP_KEEPCNT
     i = 9;
     ret = setsockopt (fd, IPPROTO_TCP, TCP_KEEPCNT, &i, len);
     if (ret < 0) {
         err ("setsockopt SO_KEEPCNT");
         goto done;
     }
+#endif
 done:
     return ret;
 }

--- a/libnpfs/user.c
+++ b/libnpfs/user.c
@@ -21,7 +21,6 @@
  *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
  *  See also: http://www.gnu.org/licenses
  *****************************************************************************/
-
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -33,9 +32,10 @@
 #include <pthread.h>
 #include <errno.h>
 #include <unistd.h>
-#include <sys/syscall.h>
 #ifndef __FreeBSD__
+#ifndef __CYGWIN__
 #include <sys/fsuid.h>
+#endif
 #endif
 #include <pwd.h>
 #include <grp.h>
@@ -43,7 +43,9 @@
 #include <sys/capability.h>
 #endif
 #ifndef __FreeBSD__
+#ifndef __CYGWIN__
 #include <sys/prctl.h>
+#endif
 #endif
 
 #include "9p.h"
@@ -578,7 +580,7 @@ done:
 int
 np_setfsid (Npreq *req, Npuser *u, u32 gid_override)
 {
-#if __FreeBSD__
+#if __FreeBSD__ || __CYGWIN__
 	return 0;
 #else
 	Npwthread *wt = req->wthread;
@@ -660,7 +662,7 @@ np_setfsid (Npreq *req, Npuser *u, u32 gid_override)
 			 * per-process, so for now bypass glibc. See issue 53.
 			 */
 			if ((srv->flags & SRV_FLAGS_SETGROUPS)) {
-				if (syscall(SYS_setgroups, u->nsg, u->sg) < 0) {
+				if (setgroups(u->nsg, u->sg) < 0) {
 					np_uerror (errno);
 					np_logerr (srv, "setgroups(%s) nsg=%d failed",
 						   u->uname, u->nsg);

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -3,7 +3,11 @@ AM_CFLAGS = @GCCWARN@
 AM_CPPFLAGS = \
 	-I../libnpfs -I../liblsd -I../libdiod -I../libnpclient
 
+if BUILD_OS_IS_CYGWIN
+sbin_PROGRAMS = diodcat dtop diodload diodls diodshowmount dioddate
+else
 sbin_PROGRAMS = diodmount diodcat dtop diodload diodls diodshowmount dioddate
+endif
 
 common_ldadd = \
 	$(top_builddir)/libdiod/libdiod.a \


### PR DESCRIPTION
This is a list of changes (need to reviewed: e.g. not using syscalls directly) that lead to cygwin compatibility. 

Seems to work without any problems with linux kernel client. 

For the first time supports reasonable cross-platform symlink interop e.g. for Linux vms on Windows.
