### PR TITLE
diod/ops.c: add header file for makedev

### DIFF
--- a/diod/ops.c
+++ b/diod/ops.c
@@ -74,6 +74,7 @@
 #include <pthread.h>
 #include <errno.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 #ifdef __FreeBSD__
 #if !__BSD_VISIBLE


### PR DESCRIPTION
Error:
diod/ops.c:845: undefined reference to `makedev'

Fixed:
Glibc removes sys/sysmacros.h which defines makedev from sys/types.h
since v2.28. [Commit ID: e16deca62e16f]

And then glibc suggestions us to include <sys/sysmacros.h> directly if
code needs it.

Signed-off-by: Hongzhi.Song <hongzhi.song@windriver.com>