### PR TITLE
Fix various tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS( \
   getopt.h \
   pthread.h \
+  sys/xattr.h \
 )
 
 ##

--- a/tests/misc/t10
+++ b/tests/misc/t10
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# skip if uid 1 doesn't exist
+getent passwd 1 >/dev/null 2>&1 || exit 77
+
 TEST=$(basename $0 | cut -d- -f1)
 ${MISC_SRCDIR}/memcheck ./tnpsrv >$TEST.out 2>&1
 diff ${MISC_SRCDIR}/$TEST.exp $TEST.out >$TEST.diff

--- a/tests/user/runtest
+++ b/tests/user/runtest
@@ -23,6 +23,8 @@ case $(basename $TEST) in
             echo "requires non-root" >$TEST.out
             exit 77
         fi
+	# requires daemon user
+	id -u daemon > /dev/null 2>&1 || exit 77
         ;;
     t11|t13|t14)
         if [ -n "$FAKEROOTEKEY" ]; then

--- a/tests/user/tsetxattr.c
+++ b/tests/user/tsetxattr.c
@@ -16,7 +16,11 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <libgen.h>
-#include <attr/xattr.h>
+#if HAVE_SYS_XATTR_H
+    #include <sys/xattr.h>
+#else
+    #include <attr/xattr.h>
+#endif
 
 
 #include "9p.h"

--- a/tests/user/txattr.c
+++ b/tests/user/txattr.c
@@ -13,7 +13,11 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <sys/types.h>
-#include <attr/xattr.h>
+#if HAVE_SYS_XATTR_H
+    #include <sys/xattr.h>
+#else
+    #include <attr/xattr.h>
+#endif
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <libgen.h>


### PR DESCRIPTION
- Some test assume the existence of the user daemon with the uid of 1.  Skip
  those if the user doesn't exists.

- Recent releases of attr don't ship attr/xattr.h anymore. It's included in
  glibc >= 2.27 as sys/xattr.h. Check for sys/xattr.h and use that if it
  exists.
