### PR TITLE
[rfc] support open-unlink-fstat

### DIFF
--- a/diod/ioctx.c
+++ b/diod/ioctx.c
@@ -275,6 +275,45 @@ ioctx_pwrite (IOCtx ioctx, const void *buf, size_t count, off_t offset)
     return pwrite (ioctx->fd, buf, count, offset);
 }
 
+int
+ioctx_stat (IOCtx ioctx, struct stat *sb)
+{
+    return fstat (ioctx->fd, sb);
+}
+
+int
+ioctx_chmod (IOCtx ioctx, u32 mode)
+{
+    return fchmod (ioctx->fd, mode);
+}
+
+int
+ioctx_chown (IOCtx ioctx, u32 uid, u32 gid)
+{
+    return fchown (ioctx->fd, uid, gid);
+}
+
+int
+ioctx_truncate (IOCtx ioctx, u64 size)
+{
+    return ftruncate (ioctx->fd, size);
+}
+
+#if HAVE_UTIMENSAT
+int
+ioctx_utimensat (IOCtx ioctx, const struct timespec ts[2], int flags)
+{
+    return futimens (ioctx->fd, ts);
+}
+
+#else /* HAVE_UTIMENSAT */
+int
+ioctx_utimes (IOCtx ioctx, const utimbuf *times)
+{
+    return futimes (ioctx->fd, times);
+}
+#endif
+
 void
 ioctx_rewinddir (IOCtx ioctx)
 {

--- a/diod/ioctx.h
+++ b/diod/ioctx.h
@@ -24,6 +24,17 @@ int     ioctx_fsync (IOCtx ioctx);
 int     ioctx_flock (IOCtx ioctx, int operation);
 int     ioctx_testlock (IOCtx ioctx, int operation);
 
+int     ioctx_stat (IOCtx ioctx, struct stat *sb);
+int     ioctx_chmod (IOCtx ioctx, u32 mode);
+int     ioctx_chown (IOCtx ioctx, u32 uid, u32 gid);
+int     ioctx_truncate (IOCtx ioctx, u64 size);
+#if HAVE_UTIMENSAT
+int     ioctx_utimensat (IOCtx ioctx, const struct timespec ts[2], int flags);
+#else
+int     ioctx_utimes (IOCtx ioctx, const utimbuf *times);
+#endif
+
+
 u32     ioctx_iounit (IOCtx ioctx);
 Npqid   *ioctx_qid (IOCtx ioctx);
 

--- a/diod/ops.c
+++ b/diod/ops.c
@@ -355,6 +355,11 @@ diod_clone (Npfid *fid, Npfid *newfid)
 {
     Fid *f = fid->aux;
 
+    if (f->ioctx != NULL) {
+        np_uerror(EBADF);
+        goto error;
+    }
+
     if (!(diod_fidclone (newfid, fid))) {
         np_uerror (ENOMEM);
         goto error;
@@ -436,6 +441,10 @@ diod_walk (Npfid *fid, Npstr* wname, Npqid *wqid)
     struct stat sb, sb2;
     Path npath = NULL;
 
+    if (f->ioctx != NULL) {
+        np_uerror (EBADF);
+        goto error_quiet;
+    }
     if ((f->flags & DIOD_FID_FLAGS_MOUNTPT)) {
         np_uerror (ENOENT);
         goto error_quiet;

--- a/libdiod/diod_sock.c
+++ b/libdiod/diod_sock.c
@@ -326,7 +326,7 @@ diod_sock_startfd (Npsrv *srv, int fdin, int fdout, char *client_id, int flags)
 void
 diod_sock_accept_one (Npsrv *srv, int fd)
 {
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr = {0};
     socklen_t addr_size = sizeof(addr);
     char host[NI_MAXHOST], ip[NI_MAXHOST], svc[NI_MAXSERV];
     int res, port;

--- a/tests/user/Makefile.am
+++ b/tests/user/Makefile.am
@@ -10,7 +10,8 @@ check_PROGRAMS = \
 	tgetxattr \
 	tsetxattr \
 	tremovexattr \
-	txattr
+	txattr \
+	testopenfid
 
 TESTS_ENVIRONMENT = env
 TESTS_ENVIRONMENT += "PATH_DIOD=$(top_builddir)/diod/diod"
@@ -19,7 +20,7 @@ TESTS_ENVIRONMENT += "USER_SRCDIR=$(top_srcdir)/tests/user"
 TESTS_ENVIRONMENT += "USER_BUILDDIR=$(top_builddir)/tests/user"
 TESTS_ENVIRONMENT += "${srcdir}/runtest"
 
-TESTS = t01 t02 t03 t04 t05 t06 t07 t08 t09 t10 t11 t12 t13 t15 t16 t17 t18 t19
+TESTS = t01 t02 t03 t04 t05 t06 t07 t08 t09 t10 t11 t12 t13 t15 t16 t17 t18 t19 t20
 
 $(TESTS): exp.d
 
@@ -55,6 +56,7 @@ tflush_SOURCES = tflush.c $(common_sources)
 tgetxattr_SOURCES = tgetxattr.c $(common_sources)
 tsetxattr_SOURCES = tsetxattr.c $(common_sources)
 tremovexattr_SOURCES = tremovexattr.c $(common_sources)
+testopenfid_SOURCES = testopenfid.c $(common_sources)
 
 clean: clean-am
 	-rm -rf exp.d

--- a/tests/user/t20
+++ b/tests/user/t20
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+./testopenfid "$@" open_walk 
+./testopenfid "$@" open_remove_read
+./testopenfid "$@" open_remove_getattr
+./testopenfid "$@" open_remove_setattr
+./testopenfid "$@" open_remove_create_setattr

--- a/tests/user/t20.exp
+++ b/tests/user/t20.exp
@@ -1,0 +1,7 @@
+testopenfid: testing 'open_walk'
+testopenfid: testing 'open_remove_read'
+testopenfid: testing 'open_remove_getattr'
+testopenfid: testing 'open_remove_setattr'
+testopenfid: testing 'open_remove_create_setattr'
+conjoin: t20 exited with rc=0
+conjoin: diod exited with rc=0

--- a/tests/user/testopenfid.c
+++ b/tests/user/testopenfid.c
@@ -1,0 +1,258 @@
+/* testopenfid.c - test operations on open fids */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "9p.h"
+#include "npfs.h"
+#include "npclient.h"
+
+#include "diod_log.h"
+#include "diod_auth.h"
+
+static void
+usage (void)
+{
+    fprintf (stderr, "Usage: topenfid aname test\n");
+    exit (1);
+}
+
+static int
+create_file (Npcfid *root, char *name, u32 mode, char *content, size_t len) {
+    Npcfid *fid;
+
+    fid = npc_create_bypath (root, name, O_TRUNC|O_RDWR, mode, getgid ());
+    if (fid == NULL) {
+        return -1;
+    }
+    if (npc_write (fid, content, len) != len) {
+        return -1;
+    }
+    if (npc_clunk (fid) == -1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+// Twalk should fail on opened fids
+static void
+open_walk (Npcfid *root) {
+    Npcfid *fid;
+
+    if (npc_mkdir_bypath (root, "subdir", 0755) == -1) {
+        errn_exit (np_rerror (), "npc_mkdir_bypath subdir");
+    }
+
+    fid = npc_open_bypath (root, "subdir", O_RDONLY);
+    if (fid == NULL) {
+        errn_exit (np_rerror (), "npc_open subdir");
+    }
+
+    if (npc_walk (fid, "..") != NULL) {
+        msg_exit ("walk succeeded on opened fid");
+    }
+
+    if (npc_clunk (fid) == -1) {
+        errn_exit (np_rerror (), "npc_clunk fid");
+    }
+}
+
+// Tread should work on opened fids even if the file has been removed
+void
+open_remove_read(Npcfid *root) {
+    Npcfid *fid;
+    char *testfile = "open_remove_read.test";
+    char buf[3];
+
+    if (create_file(root, testfile, 0644, "foo", 3) == -1) {
+        errn_exit (np_rerror (), "create_file %s", testfile);
+    }
+
+    fid = npc_open_bypath(root, testfile, O_RDONLY);
+    if (fid == NULL) {
+        errn_exit (np_rerror (), "npc_open %s", testfile);
+    }
+
+    if (npc_remove_bypath(root, testfile) == -1) {
+        errn_exit (np_rerror (), "npc_remove_bypath %s", testfile);
+    }
+
+    if (npc_read(fid, buf, sizeof(buf)) != sizeof(buf)) {
+        errn_exit (np_rerror (), "npc_read fid");
+    }
+
+    if (npc_clunk(fid) == -1) {
+        errn_exit (np_rerror (), "npc_clunk fid");
+    }
+}
+
+// Tgetattr should work on opened fids even if the file has been removed
+void
+open_remove_getattr (Npcfid *root) {
+    Npcfid *fid;
+    char *testfile = "open_remove_getattr.test";
+    struct stat sb, osb;
+
+    if (create_file (root, testfile, 0644, "foo", 3) == -1) {
+        errn_exit (np_rerror (), "create_file %s", testfile);
+    }
+
+    if (npc_stat (root, testfile, &sb) == -1) {
+        errn_exit (np_rerror (), "npc_stat %s", testfile);
+    }
+
+    fid = npc_open_bypath (root, testfile, O_RDONLY);
+    if (fid == NULL) {
+        errn_exit (np_rerror (), "npc_open %s", testfile);
+    }
+
+    if (npc_remove_bypath (root, testfile) == -1) {
+        errn_exit (np_rerror (), "npc_remove %s", testfile);
+    }
+
+    if (npc_fstat (fid, &osb) == -1) {
+        errn_exit (np_rerror (), "npc_dstat fid");
+    }
+
+    if (npc_clunk (fid) == -1) {
+        errn_exit (np_rerror (), "npc_clunk fid");
+    }
+}
+
+// Tsetattr should work on opened fids even if the file has been removed
+void
+open_remove_setattr (Npcfid *root) {
+    Npcfid *fid;
+    char *testfile = "open_remove_setattr.test";
+    struct stat sb;
+
+    if (create_file (root, testfile, 0644, "foo", 3) == -1) {
+        errn_exit (np_rerror (), "create_file %s", testfile);
+    }
+
+    if (npc_stat (root, testfile, &sb) == -1) {
+        errn_exit (np_rerror (), "npc_stat %s", testfile);
+    }
+
+    fid = npc_open_bypath (root, testfile, O_RDONLY);
+    if (fid == NULL) {
+        errn_exit (np_rerror (), "npc_open %s", testfile);
+    }
+
+    if (npc_remove_bypath (root, testfile) == -1) {
+        errn_exit (np_rerror (), "npc_remove %s", testfile);
+    }
+
+    if (npc_fchmod (fid, 0444) == -1) {
+        errn_exit (np_rerror (), "npc_fchmod fid");
+    }
+
+    if (npc_clunk (fid) == -1) {
+        errn_exit (np_rerror (), "npc_clunk fid");
+    }
+}
+
+// Tsetattr on a fid opened from path should not affect path when path is no longer the same file
+void
+open_remove_create_setattr (Npcfid *root) {
+    Npcfid *fid;
+    char *testfile = "open_remove_create_setattr.test";
+    struct stat sb;
+
+    if (create_file (root, testfile, 0644, "foo", 3) == -1) {
+        errn_exit (np_rerror (), "create_file %s", testfile);
+    }
+
+    fid = npc_open_bypath (root, testfile, O_RDONLY);
+    if (fid == NULL) {
+        errn_exit (np_rerror (), "npc_open %s", testfile);
+    }
+
+    if (npc_remove_bypath (root, testfile) == -1) {
+        errn_exit (np_rerror (), "npc_remove %s", testfile);
+    }
+    if (create_file (root, testfile, 0644, "foo", 3) == -1) {
+        errn_exit (np_rerror (), "create_file %s", testfile);
+    }
+
+    if (npc_fchmod (fid, 0444) == -1) {
+        errn_exit (np_rerror (), "npc_fchmod fid");
+    }
+    if (npc_fstat (fid, &sb) == -1) {
+        errn_exit (np_rerror (), "npc_fstat fid");
+    }
+    if ((sb.st_mode & 0x777) != 0444) {
+        msg_exit ("fchmod didn't change sb.st_mode");
+    }
+
+    if (npc_stat (root, testfile, &sb) == -1) {
+        errn_exit (np_rerror (), "npc_stat %s", testfile);
+    }
+    if ((sb.st_mode & 0777) != 0644) {
+        msg_exit ("stat changed %o", sb.st_mode);
+    }
+
+    if (npc_clunk (fid) == -1) {
+        errn_exit (np_rerror (), "npc_clunk fid");
+    }
+}
+
+int
+main (int argc, char *argv[])
+{
+    Npcfsys *fs;
+    Npcfid *afid, *root;
+    uid_t uid = geteuid ();
+    char *aname, *test;
+    int fd = 0; /* stdin */
+
+    diod_log_init (argv[0]);
+
+    if (argc < 3)
+        usage ();
+    aname = argv[1];
+    test = argv[2];
+
+    if (!(fs = npc_start (fd, fd, 65536+24, 0)))
+        errn_exit (np_rerror (), "npc_start");
+    if (!(afid = npc_auth (fs, aname, uid, diod_auth)) && np_rerror () != 0)
+        errn_exit (np_rerror (), "npc_auth");
+    if (!(root = npc_attach (fs, afid, aname, uid)))
+        errn_exit (np_rerror (), "npc_attach");
+    if (afid && npc_clunk (afid) < 0)
+        errn (np_rerror (), "npc_clunk afid");
+
+    msg("testing '%s'", test);
+    if (strcmp(test, "open_walk") == 0) {
+        open_walk (root);
+    } else if (strcmp (test, "open_remove_read") == 0) {
+        open_remove_read (root);
+    } else if (strcmp (test, "open_remove_getattr") == 0) {
+        open_remove_getattr (root);
+    } else if (strcmp (test, "open_remove_setattr") == 0) {
+        open_remove_setattr (root);
+    } else if (strcmp (test, "open_remove_create_setattr") == 0) {
+        open_remove_create_setattr (root);
+    } else {
+        fprintf (stderr, "unknown test %s\n", test);
+        exit (1);
+    }
+    npc_finish (fs);
+
+    exit(0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This is a first attempt at making open-unlink-fstat work (#19, #47). The basic
idea is to extend IOCtx to support stat,chmod/chown/etc. and then simply
delegate to it when the Fid->ioctx is set.

Tests are in `tests/user/t20` `tests/user/testopenfid.c`.

27a5976 is unrelated but required to get tests/misc/t15 pass on my system. 








