### PR TITLE
libnpclient/read.c: fix out-of-bounds write

### DIFF
--- a/libnpclient/read.c
+++ b/libnpclient/read.c
@@ -58,6 +58,10 @@ npc_pread(Npcfid *fid, void *buf, u32 count, u64 offset)
 	}
 	if (fid->fsys->rpc(fid->fsys, tc, &rc) < 0)
 		goto done;
+	if (rc->u.rread.count > count) {
+		np_uerror (EPROTO);
+		goto done;
+	}
 	memmove(buf, rc->u.rread.data, rc->u.rread.count);
 	ret = rc->u.rread.count;
 done:


### PR DESCRIPTION
Don't assume Rread.count is always <= Tread.count.

As far as I can see this only affects `diodcat`.