### PR TITLE
Place systemd unit into $(libdir)/systemd/system

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,4 +1,4 @@
-systemddir=$(sysconfdir)/systemd/system
+systemddir=$(libdir)/systemd/system
 
 install-data-local:
 	$(top_srcdir)/config/install-sh -m 755 $(srcdir)/auto.diod \


### PR DESCRIPTION
systemd.unit(5) states that units of installed packages belong in
`/usr/lib/systemd/system`. `/etc/systemd/system` is reserved for local
configuration (i.e. the administrator).