### PR TITLE
Fix systemd build with diod.spec, suggestion to split package in diod{,-utils}

### DIFF
--- a/diod.spec.in
+++ b/diod.spec.in
@@ -60,10 +60,24 @@ fi
 %files
 %defattr(-,root,root)
 %doc AUTHORS COPYING README INSTALL ChangeLog
-%{_sbindir}/*
-/sbin/*
-%{_mandir}/man8/*
-%{_mandir}/man5/*
-%attr(0755,root,root) %{_sysconfdir}/systemd/system/diod.service
+%{_sbindir}/diod
+%{_mandir}/man8/diod.*
+%{_mandir}/man5/diod.*
+%attr(0755,root,root) %{_unitdir}/diod.service
 %config(noreplace) %attr(0755,root,root) %{_sysconfdir}/auto.diod
 %config(noreplace) %attr(0644,root,root) %{_sysconfdir}/diod.conf
+
+%package utils
+Summary:  Utilities for diod, a I/O forwarding server for 9P
+
+%description utils
+Utilities related to the diod 9P file server.
+
+%files utils
+%defattr(-,root,root)
+/sbin/mount.diod
+%{_sbindir}/diod?*
+%{_sbindir}/dtop
+%{_mandir}/man8/diod?*.8.gz
+%{_mandir}/man8/dtop.8.gz
+%{_mandir}/man8/mount.diod.8.gz

--- a/diod.spec.in
+++ b/diod.spec.in
@@ -17,6 +17,7 @@ BuildRequires: libcap-devel
 #BuildRequires: libibverbs-devel librdmacm-devel
 #BuildRequires: gperftools-devel
 BuildRequires: libattr-devel attr
+BuildRequires: systemd
 
 %description
 diod is a 9P server used in combination with the kernel v9fs file

--- a/diod/Makefile.am
+++ b/diod/Makefile.am
@@ -3,7 +3,7 @@ AM_CFLAGS = @GCCWARN@
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/libnpfs \
 	-I$(top_srcdir)/liblsd \
-	-I$(top_srcdir)//libdiod
+	-I$(top_srcdir)/libdiod
 
 sbin_PROGRAMS = diod
 


### PR DESCRIPTION
This PR fixes a build issue when using the spec file. The systemd dependency is required for the build to complete, as well as a removing an extra slash in a Makefile. It would be possible to avoid the hard systemd dependency by using the `%{?systemd_requires}` macro, if you prefer.

The second commit suggests splitting diod in two packages: the main server, diod, and client utilities, such as the mount helper, in diod-utils. Clients don't need to have the diod server running, which is started by default as a post-installation step in the spec file. If that's not desired, I can easily remove the commit.