### PR TITLE
Support IPv6 addresses

### DIFF
--- a/diod/diod.8.in
+++ b/diod/diod.8.in
@@ -28,6 +28,7 @@ the two options may be set to the same value.
 .I "-l, --listen address"
 Set the listen address.  The address may be in the form of
 HOST:PORT, IP:PORT, or /path/to/unix_domain_socket form (default 0.0.0.0:564).
+IPv6 addresses must be enclosed in square brackets.
 This option may be specified more than once.
 It overrides the \fIlisten\fR config file setting.
 .TP

--- a/diod/diod.c
+++ b/diod/diod.c
@@ -188,6 +188,12 @@ main(int argc, char **argv)
                     diod_conf_clr_listen ();
                 if (!strchr (optarg, ':') && optarg[0] != '/')
                     usage ();
+                if (optarg[0] == '[') {
+                    char *end = strchr (optarg, ']');
+
+                    if (!end || !strchr (end, ':'))
+                        usage ();
+                }
                 diod_conf_add_listen (optarg);
                 break;
             case 't':   /* --nwthreads INT */

--- a/libdiod/diod_sock.c
+++ b/libdiod/diod_sock.c
@@ -276,11 +276,26 @@ diod_sock_listen (List l, struct pollfd **fdsp, int *nfdsp)
                 goto done;
             ret += n;
         } else {
+            char *hostend;
+            int ipv6 = 0;
+
+            if (s[0] == '[') {
+                ipv6 = 1;
+                s++;
+            }
+
             if (!(host = strdup (s))) {
                 msg ("out of memory");
                 goto done;
             }
-            port = strchr (host, ':');
+            if (ipv6) {
+                hostend = strchr (host, ']');
+                NP_ASSERT (hostend != NULL);
+                *hostend++ = '\0';
+            } else {
+                hostend = host;
+            }
+            port = strchr (hostend, ':');
             NP_ASSERT (port != NULL);
             *port++ = '\0';
             if ((n = _setup_one_inet (host, port, fdsp, nfdsp)) == 0) {

--- a/utils/diodmount.8.in
+++ b/utils/diodmount.8.in
@@ -29,6 +29,9 @@ Post-connect mount errors are immediately fatal.
 .LP
 If the \fIhost\fR portion of the mount spec begins with a forward-slash (/),
 it refers to the path to a UNIX domain socket.
+.LP
+IPv6 addresses may be used for the \fIhost\fR portion of the mount spec if they
+are enclosed in square brackets.
 .SH COMMAND LINE OPTIONS
 .TP
 .I "-f, --fake-mount"


### PR DESCRIPTION
This allows raw IPv6 addresses to be specified in the command-line arguments to diod and diodmount.  Square brackets are used to specify IPv6 addresses, similar to NFS and socat.