### PR TITLE
Remove empty README

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ X_AC_EXPAND_INSTALL_DIRS
 ##
 # Automake support
 ##
-AM_INIT_AUTOMAKE([subdir-objects]
+AM_INIT_AUTOMAKE([subdir-objects foreign]
 		m4_esyscmd([case `automake --version | head -n 1` in
                              *1.11*);;
                              *) echo serial-tests;;


### PR DESCRIPTION
The README file is empty since the contents were moved to README.md.  I think it was not the intention to have the empty README file still present so this removes it.