### PR TITLE
Add option to disable hostname lookups

### DIFF
--- a/diod/diod.8.in
+++ b/diod/diod.8.in
@@ -54,6 +54,10 @@ This option overrides the \fIexportopts\fR setting in diod.conf (5).
 This option allows users to attach without security credentials.
 It overrides  the \fIauth_required\fR setting in diod.conf (5).
 .TP
+.I "-H, --no-hostname-lookup"
+This option disables hostname lookups.
+It overrides the \fIhostname_lookup\fR setting in diod.conf (5).
+.TP
 .I "-N, --no-userdb"
 This option disables password/group lookups.
 It allows any uid to attach and assumes gid=uid, and supplementary groups

--- a/etc/diod.conf.5.in
+++ b/etc/diod.conf.5.in
@@ -47,6 +47,9 @@ for a unique aname.  The default is 16 per aname.
 Allow clients to connect without authentication, i.e. without a valid
 MUNGE credential.
 .TP
+.I "hostname_lookup = 0"
+This option disables hostname lookups.
+.TP
 .I "userdb = 0"
 This option disables password/group lookups.
 It allows any uid to attach and assumes gid=uid, and supplementary groups

--- a/libdiod/diod_conf.c
+++ b/libdiod/diod_conf.c
@@ -86,12 +86,14 @@
 #define RO_SQUASHUSER           0x00008000
 #define RO_STATFS_PASSTHRU      0x00010000
 #define RO_AUTH_REQUIRED_CTL    0x00020000
+#define RO_HOSTNAME_LOOKUP      0x00040000
 
 typedef struct {
     int          debuglevel;
     int          nwthreads;
     int          foreground;
     int          auth_required;
+    int          hostname_lookup;
     int          statfs_passthru;
     int          userdb;
     int          allsquash;
@@ -179,6 +181,7 @@ diod_conf_init (void)
     config.nwthreads = DFLT_NWTHREADS;
     config.foreground = DFLT_FOREGROUND;
     config.auth_required = DFLT_AUTH_REQUIRED;
+    config.hostname_lookup = DFLT_HOSTNAME_LOOKUP;
     config.statfs_passthru = DFLT_STATFS_PASSTHRU;
     config.userdb = DFLT_USERDB;
     config.allsquash = DFLT_ALLSQUASH;
@@ -271,6 +274,16 @@ void diod_conf_set_auth_required (int i)
 {
     config.auth_required = i;
     config.ro_mask |= RO_AUTH_REQUIRED;
+}
+
+/* hostname_lookup - whether hostnames should be looked up
+ */
+int diod_conf_get_hostname_lookup (void) { return config.hostname_lookup; }
+int diod_conf_opt_hostname_lookup (void) { return config.ro_mask & RO_HOSTNAME_LOOKUP; }
+void diod_conf_set_hostname_lookup (int i)
+{
+    config.hostname_lookup = i;
+    config.ro_mask |= RO_HOSTNAME_LOOKUP;
 }
 
 /* statfs_passthru - whether statfs should return host f_type or V9FS_MAGIC
@@ -650,6 +663,11 @@ diod_conf_init_config_file (char *path) /* FIXME: ENOMEM is fatal */
             config.auth_required = DFLT_AUTH_REQUIRED;
             _lua_getglobal_int (path, L, "auth_required",
                                 &config.auth_required);
+        }
+        if (!(config.ro_mask & RO_HOSTNAME_LOOKUP)) {
+            config.hostname_lookup = DFLT_HOSTNAME_LOOKUP;
+            _lua_getglobal_int (path, L, "hostname_lookup",
+                                &config.hostname_lookup);
         }
         if (!(config.ro_mask & RO_STATFS_PASSTHRU)) {
             config.statfs_passthru = DFLT_STATFS_PASSTHRU;

--- a/libdiod/diod_conf.h
+++ b/libdiod/diod_conf.h
@@ -3,6 +3,7 @@
 #define DFLT_MAXMMAP            0
 #define DFLT_FOREGROUND         0
 #define DFLT_AUTH_REQUIRED      1
+#define DFLT_HOSTNAME_LOOKUP    1
 #define DFLT_STATFS_PASSTHRU    0
 #define DFLT_USERDB             1
 #define DFLT_ALLSQUASH          0
@@ -41,6 +42,10 @@ void    diod_conf_set_foreground (int i);
 int     diod_conf_get_auth_required (void);
 int     diod_conf_opt_auth_required (void);
 void    diod_conf_set_auth_required (int i);
+
+int     diod_conf_get_hostname_lookup (void);
+int     diod_conf_opt_hostname_lookup (void);
+void    diod_conf_set_hostname_lookup (int i);
 
 int     diod_conf_get_statfs_passthru (void);
 int     diod_conf_opt_statfs_passthru (void);

--- a/libdiod/diod_sock.c
+++ b/libdiod/diod_sock.c
@@ -339,7 +339,7 @@ diod_sock_startfd (Npsrv *srv, int fdin, int fdout, char *client_id, int flags)
 /* Accept one connection on a ready fd and pass it on to the npfs 9P engine.
  */
 void
-diod_sock_accept_one (Npsrv *srv, int fd)
+diod_sock_accept_one (Npsrv *srv, int fd, int lookup)
 {
     struct sockaddr_storage addr = {0};
     socklen_t addr_size = sizeof(addr);
@@ -365,8 +365,9 @@ diod_sock_accept_one (Npsrv *srv, int fd)
         (void)_disable_nagle (fd);
         (void)_enable_keepalive (fd);
     }
-    if ((res = getnameinfo ((struct sockaddr *)&addr, addr_size,
-                            host, sizeof(host), NULL, 0, 0))) {
+    host[0] = '\0';
+    if (lookup && (res = getnameinfo ((struct sockaddr *)&addr, addr_size,
+                                      host, sizeof(host), NULL, 0, 0))) {
         msg ("getnameinfo: %s", gai_strerror(res));
         close (fd);
         return;

--- a/libdiod/diod_sock.h
+++ b/libdiod/diod_sock.h
@@ -1,6 +1,6 @@
 struct pollfd;
 
-void diod_sock_accept_one (Npsrv *srv, int fd);
+void diod_sock_accept_one (Npsrv *srv, int fd, int lookup);
 
 void diod_sock_startfd (Npsrv *srv, int fdin, int fdout, char *client_id,
                         int flags);


### PR DESCRIPTION
diod attempts to lookup clients' hostnames with reverse DNS and this
prevents client from connecting if the server does not have working DNS
("diod: getnameinfo: Temporary failure in name resolution").  Add an
option to disable these hostname lookups for systems which do not need
them.