### PR TITLE
Increase server msize up to 1M which is becoming standard and default for 9p tcp buffers as of kernels 5.15-rc1

### DIFF
--- a/diod/ops.c
+++ b/diod/ops.c
@@ -121,6 +121,8 @@
 #include "xattr.h"
 #include "fid.h"
 
+#define DIOD_SRV_MAX_MSIZE 1048576
+
 Npfcall     *diod_attach (Npfid *fid, Npfid *afid, Npstr *aname);
 int          diod_clone  (Npfid *fid, Npfid *newfid);
 int          diod_walk   (Npfid *fid, Npstr *wname, Npqid *wqid);
@@ -162,7 +164,7 @@ char        *diod_get_files (char *name, void *a);
 int
 diod_init (Npsrv *srv)
 {
-    srv->msize = 65536;
+    srv->msize = DIOD_SRV_MAX_MSIZE;
     srv->fiddestroy = diod_fiddestroy;
     srv->logmsg = diod_log_msg;
     srv->remapuser = diod_remapuser;


### PR DESCRIPTION
As of kernels 5.15 the tcp max buffer size has been increased to 1M
thus we can increase our server maximum to 1M too. This brings huge performance increase, as the client
can now mount with msize=1048576 and this will be respected. For reference:
https://github.com/torvalds/linux/commit/22bb3b79290ec5970b74fa6e9eb313802d075c82
Also, the default on the client has been increased to 128K, reference:
https://github.com/torvalds/linux/commit/9c4d94dc9a64426d2fa0255097a3a84f6ff2eebe#diff-8ca710cee9d036f79b388ea417a11afa79f70bdbfca99c938e750e4ff3b4402d