### PR TITLE
Silence warnings when compiling with clang

### DIFF
--- a/libnpfs/npfs.h
+++ b/libnpfs/npfs.h
@@ -370,7 +370,7 @@ void np_tpool_incref(Nptpool *);
 void np_tpool_decref(Nptpool *);
 int np_decode_tpools_str (char *s, Npstats *stats);
 void np_assfail (char *ass, char *file, int line);
-#define NP_ASSERT(exp) if ((exp)) ; else np_assfail(#exp, __FILE__, __LINE__ ) 
+#define NP_ASSERT(exp) if (exp) ; else np_assfail(#exp, __FILE__, __LINE__ )
 
 /* conn.c */
 Npconn *np_conn_create(Npsrv *, Nptrans *, char *, int);


### PR DESCRIPTION
When compiling with clang, the compiler generates multiple warnings
due to extraneous parenthesis declaration.

This silence those and does not create a problem when compiling
with gcc toolchains either.