### PR TITLE
allow open+walk to get diod working with linux v9fs again

### DIFF
--- a/diod/ops.c
+++ b/diod/ops.c
@@ -336,11 +336,6 @@ diod_clone (Npfid *fid, Npfid *newfid)
 {
     Fid *f = fid->aux;
 
-    if (f->ioctx != NULL) {
-        np_uerror(EBADF);
-        goto error;
-    }
-
     if (!(diod_fidclone (newfid, fid))) {
         np_uerror (ENOMEM);
         goto error;
@@ -422,10 +417,6 @@ diod_walk (Npfid *fid, Npstr* wname, Npqid *wqid)
     struct stat sb, sb2;
     Path npath = NULL;
 
-    if (f->ioctx != NULL) {
-        np_uerror (EBADF);
-        goto error_quiet;
-    }
     if ((f->flags & DIOD_FID_FLAGS_MOUNTPT)) {
         np_uerror (ENOENT);
         goto error_quiet;

--- a/tests/user/t20
+++ b/tests/user/t20
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-./testopenfid "$@" open_walk 
+# ./testopenfid "$@" open_walk
 ./testopenfid "$@" open_remove_read
 ./testopenfid "$@" open_remove_getattr
 ./testopenfid "$@" open_remove_setattr

--- a/tests/user/t20.exp
+++ b/tests/user/t20.exp
@@ -1,4 +1,3 @@
-testopenfid: testing 'open_walk'
 testopenfid: testing 'open_remove_read'
 testopenfid: testing 'open_remove_getattr'
 testopenfid: testing 'open_remove_setattr'


### PR DESCRIPTION
As reported in #70, diod doesn't seem to handle a simple ls -l in a v9fs-mounted directory since commit 6749db36c8d297d22083def10c76ea1736a519b4.

This PR reverts that commit and disables an associated test to get us working again.

I don't know if the kernel behavior is wrong or if the [walk(5)](http://man.cat-v.org/plan_9/5/walk) interpretation that motivated the commit and test is wrong, but I am out of time for now, hence this PR.