### PR TITLE
github: extend build matrix to include ubuntu18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,12 @@ on: [ pull_request, push ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
 
     strategy:
       matrix:
         cc: [gcc, clang]
+        os: [ubuntu-latest, ubuntu-18.04]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Problem: CI does not build diod on older OS.

Add the ubuntu-18.04 runner to the build matrix.