### PR TITLE
Use privport with ipv6

### DIFF
--- a/libdiod/diod_sock.c
+++ b/libdiod/diod_sock.c
@@ -396,6 +396,30 @@ _bind_priv_inet4 (int sockfd)
     return rc;
 }
 
+/* Bind socket to a local IPv6 port < 1024.
+ */
+static int
+_bind_priv_inet6 (int sockfd)
+{
+    struct sockaddr_in6 in;
+    int port;
+    int rc = -1;
+
+    memset (&in, 0, sizeof(in));
+    in.sin6_family = AF_INET6;
+    in.sin6_addr = in6addr_any;
+
+    for (port = IPPORT_RESERVED - 1; port >= IPPORT_RESERVED / 2; port--) {
+        in.sin6_port = htons ((ushort)port);
+        rc = bind(sockfd, (struct sockaddr *) &in, sizeof(in));
+        if (rc == 0 || (rc < 0 && errno != EADDRINUSE))
+            break;
+    }
+    if (rc < 0 && errno == EADDRINUSE)
+        errno = EAGAIN;
+    return rc;
+}
+
 /* Connect to host:port.
  * Return fd on success, -1 on failure.
  */
@@ -428,16 +452,25 @@ diod_sock_connect_inet (char *host, char *port, int flags)
             continue;
         }
         if (flags & DIOD_SOCK_PRIVPORT) {
-            if (r->ai_family != AF_INET) {
+            if (r->ai_family == AF_INET) {
+                if (_bind_priv_inet4 (fd) < 0) {
+                    errnum = errno;
+                    errmsg = "_bind_resv_inet4";
+                    (void)close (fd);
+                    fd = -1;
+                    continue;
+                }
+            } else if (r->ai_family == AF_INET6) {
+                if (_bind_priv_inet6 (fd) < 0) {
+                    errnum = errno;
+                    errmsg = "_bind_resv_inet6";
+                    (void)close (fd);
+                    fd = -1;
+                    continue;
+                }
+            } else {
                 errnum = EINVAL;
-                errmsg = "_bind_resv_inet4";
-                (void)close (fd);
-                fd = -1;
-                continue;
-            }
-            if (_bind_priv_inet4 (fd) < 0) {
-                errnum = errno;
-                errmsg = "_bind_resv_inet4";
+                errmsg = "protocol";
                 (void)close (fd);
                 fd = -1;
                 continue;

--- a/utils/diodmount.8.in
+++ b/utils/diodmount.8.in
@@ -45,6 +45,11 @@ Set verbose mode.
 .TP
 .I "-o, --options opt[,opt,...]"
 Set mount options (see below).
+.TP
+.I "-p, --privport"
+Connect from a socket bound to a port in the range of 512-1023,
+available to root only.  This can be used in conjunction with the
+\fIprivport\fR export option.
 .SH MOUNT OPTIONS
 The following file system specific mount options are handled by
 \fBmount.diod\fR.


### PR DESCRIPTION
These patches make it possible to use the privport option using ipv6.
The also make it possible to specify using privport on cmdline for both diod and diodmount
  - For diodmount they do it by adding a new parameter (-p)
  - For diod they do it by looking at the content of the -o parameter also together with exports specified with -e parameters. The the privport option can be sent in using -o.

