### PR TITLE
Shutdown cleanup

### DIFF
--- a/diod/diod.c
+++ b/diod/diod.c
@@ -676,6 +676,7 @@ _service_run (srvmode_t mode, int rfdno, int wfdno)
         errn_exit (n, "pthread_join _service_loop_rdma");
 #endif
 
+    np_srv_shutdown(ss.srv);
     diod_fini (ss.srv);
     np_srv_destroy (ss.srv);
 }

--- a/libnpfs/conn.c
+++ b/libnpfs/conn.c
@@ -99,7 +99,7 @@ np_conn_destroy(Npconn *conn)
 	NP_ASSERT(conn->refcount == 0);
 	/* issue 83: remove from srv->conns before destroying fidpool
  	 */
-	np_srv_remove_conn (conn->srv, conn);
+	np_srv_remove_conn_pre(conn->srv, conn);
 	if (conn->fidpool) {
 		if ((n = np_fidpool_destroy(conn->fidpool)) > 0) {
 			np_logmsg (conn->srv, "%s: connection closed with "
@@ -116,6 +116,7 @@ np_conn_destroy(Npconn *conn)
 	pthread_mutex_destroy(&conn->wlock);
 	pthread_cond_destroy(&conn->refcond);
 
+	np_srv_remove_conn_post(conn->srv);
 	free(conn);
 }
 

--- a/libnpfs/conn.c
+++ b/libnpfs/conn.c
@@ -86,8 +86,8 @@ np_conn_decref(Npconn *conn)
 	xpthread_mutex_lock(&conn->lock);
 	NP_ASSERT(conn->refcount > 0);
 	conn->refcount--;
-	xpthread_mutex_unlock(&conn->lock);
 	xpthread_cond_signal(&conn->refcond);
+	xpthread_mutex_unlock(&conn->lock);
 }
 
 static void

--- a/libnpfs/npfs.h
+++ b/libnpfs/npfs.h
@@ -342,7 +342,8 @@ struct Npuser {
 /* srv.c */
 Npsrv *np_srv_create(int nwthread, int flags);
 void np_srv_destroy(Npsrv *srv);
-void np_srv_remove_conn(Npsrv *, Npconn *);
+void np_srv_remove_conn_pre(Npsrv *, Npconn *);
+void np_srv_remove_conn_post(Npsrv *);
 int np_srv_add_conn(Npsrv *, Npconn *);
 void np_srv_wait_conncount(Npsrv *srv, int count);
 void np_req_respond(Npreq *req, Npfcall *rc);

--- a/libnpfs/npfs.h
+++ b/libnpfs/npfs.h
@@ -342,6 +342,7 @@ struct Npuser {
 /* srv.c */
 Npsrv *np_srv_create(int nwthread, int flags);
 void np_srv_destroy(Npsrv *srv);
+void np_srv_shutdown(Npsrv *srv);
 void np_srv_remove_conn_pre(Npsrv *, Npconn *);
 void np_srv_remove_conn_post(Npsrv *);
 int np_srv_add_conn(Npsrv *, Npconn *);

--- a/libnpfs/srv.c
+++ b/libnpfs/srv.c
@@ -78,6 +78,23 @@ error:
 	return NULL;
 }
 
+/* Shut down all connection */
+void
+np_srv_shutdown(Npsrv *srv)
+{
+	Npconn *cc;
+
+	/* Shut down all connections */
+	xpthread_mutex_lock(&srv->lock);
+	for (cc = srv->conns; cc != NULL; cc = cc->next)
+		pthread_cancel(cc->rthread);
+
+	/* Wait for all connections to shutdown... */
+	while (srv->conncount > 0)
+		xpthread_cond_wait(&srv->conncountcond, &srv->lock);
+	xpthread_mutex_unlock(&srv->lock);
+}
+
 void
 np_srv_destroy(Npsrv *srv)
 {


### PR DESCRIPTION
Hi,

We have had problems with diod crashing during shutdown and found out that there are races between thread shutdown and data deallocations.

I have made some patches here that I think solves it (at least we cannot trigger the crashes anymore).