### PR TITLE
Handle various time_t sizes in printf and scanf

### DIFF
--- a/libnpfs/conn.c
+++ b/libnpfs/conn.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <errno.h>
 #include <pthread.h>
@@ -132,8 +133,8 @@ _debug_trace (Npsrv *srv, Npfcall *fc)
 				(void)gettimeofday(&b, NULL);
 			(void)gettimeofday(&a, NULL);
 			timersub(&a, &b, &c);
-			np_logmsg(srv, "[%lu.%-3lu] %s",
-				  c.tv_sec, c.tv_usec/1000, s);
+			np_logmsg(srv, "[%"PRIdMAX".%-3"PRIdMAX"] %s",
+				  (intmax_t)c.tv_sec, (intmax_t)c.tv_usec/1000, s);
 		} else
 			np_logmsg(srv, "%s", s);
 	}

--- a/libnpfs/ctl.c
+++ b/libnpfs/ctl.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <pthread.h>
 #include <errno.h>
@@ -291,9 +292,9 @@ _ctl_get_date (char *name, void *a)
 		np_uerror (errno);
 		goto error;
 	}
-	if (aspf (&s, &len, "%lu.%lu %d.%d\n",
-					tv.tv_sec,         tv.tv_usec,
-					tz.tz_minuteswest, tz.tz_dsttime) < 0) {
+	if (aspf (&s, &len, "%"PRIdMAX".%"PRIdMAX" %d.%d\n",
+					(uintmax_t)tv.tv_sec, (uintmax_t)tv.tv_usec,
+					tz.tz_minuteswest,    tz.tz_dsttime) < 0) {
 		np_uerror (ENOMEM);
 		goto error;
 	}

--- a/utils/dioddate.c
+++ b/utils/dioddate.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #if HAVE_GETOPT_H
@@ -142,11 +143,16 @@ main (int argc, char *argv[])
         errn (np_rerror (), "error reading date");
         goto done;
     }
-    if (sscanf (buf, "%lu.%lu %d.%d", &tv.tv_sec, &tv.tv_usec,
+
+    int64_t sec = 0, usec = 0;
+    if (sscanf (buf, "%"SCNd64".%"SCNd64" %d.%d", &sec, &usec,
                                     &tz.tz_minuteswest, &tz.tz_dsttime) != 4) {
         msg ("error scanning returned date: %s", buf);
         goto done;
     }
+    tv.tv_sec = sec;
+    tv.tv_usec = usec;
+
     if (Sopt) {
         if (settimeofday (&tv, &tz) < 0)
             err_exit ("settimeofday");


### PR DESCRIPTION
The members of the timeval struct are both signed (defined by POSIX) and typically both 64 bits on a system where time_t is 64 bits.  This is possible also on 32 bit systems where time_t is larger to handle the 2038 problem.

It's practically impossible to find a type and printf format that works even on all glibc systems.  Play it safe and always use printf with intmax_t and explict int64_t variables for scanf.

Alternatively, we could use autoconf to figure out the sizes and printf format specifiers, but that seemed way to complicated for what we would gain.

Note that I've changes some prints from unsigned to signed, but the data types were always signed anyway and any negative values would probably have resulted in some odd-looking timestamps.