### PR TITLE
test fixes

### DIFF
--- a/tests/kern/Makefile.am
+++ b/tests/kern/Makefile.am
@@ -31,7 +31,7 @@ TESTS = t05 t06 t07 t12 t13 t14 t15 t16 t17 t18 t19 t22 \
 	t23 t24 t25 t26 t27 t28 t29 t30 t31 t32 t33 \
 	t34 t35 t36 t37 t38 t39 t40 t41 t42 t43 t44 t45 t46 t47
 
-XFAIL_TESTS = t48 t49
+XFAIL_TESTS = t19 t23 t32 t37 t43 t47 t48 t49
 
 CLEANFILES = *.out *.diff *.diod *.postmark *.dbench
 

--- a/tests/kern/runtest
+++ b/tests/kern/runtest
@@ -33,6 +33,11 @@ if ! modprobe 9p 2>/dev/null; then
     exit 77
 fi
 rm -f $TEST.diod $TEST.out
+# t28 requires rsync
+if [ "$TEST" = "t28" ] && ! which rsync >/dev/null 2>&1; then
+    echo "rsync is not installed" >$TEST.out
+    exit 77
+fi
 # t29 requires tclsh
 if [ "$TEST" = "t29" ] && ! which tclsh >/dev/null 2>&1; then
     echo "tclsh is not installed" >$TEST.out

--- a/tests/kern/runtest
+++ b/tests/kern/runtest
@@ -124,13 +124,14 @@ fi
     "${KERN_SRCDIR}/$TEST" \
     >$TEST.out 2>&1
 rc=$?
+
+[ -d "$PATH_EXPDIR" ] && rm -rf "$PATH_EXPDIR"
+[ -d "$PATH_MNTDIR" ] && rm -rf "$PATH_MNTDIR"
+
 if [ $rc != 0 ]; then
     echo "test exited with $rc" >>$TEST.out
     exit $rc
 fi
-
-[ -d "$PATH_EXPDIR" ] && rm -rf $PATH_EXPDIR
-[ -d "$PATH_MNTDIR" ] && rm -rf $PATH_MNTDIR
 
 diff ${KERN_SRCDIR}/$TEST.exp $TEST.out >$TEST.diff
 exit $?

--- a/tests/kern/runtest
+++ b/tests/kern/runtest
@@ -105,6 +105,21 @@ chmod 755 $PATH_MNTDIR $PATH_EXPDIR
 export PATH_EXPDIR
 export PATH_MNTDIR
 
+# t35 and t40 requires a certain amount of disk space
+# It's not possible to check until $PATH_MNTDIR is created
+case "$TEST" in
+	t35|t40)
+		avail=$(df -B1024K --output=avail "$PATH_MNTDIR" | tail -n1)
+		case "$TEST" in
+			t35) required=500;;
+			t40) required=100;;
+		esac
+		if [ "$avail" -lt "$required" ]; then
+			echo "Requires ${required}MB free space on $PATH_MNTDIR, only ${avail}MB available" >"$TEST.out"
+			exit 77
+		fi;;
+esac
+
 export MALLOC_CHECK_=3
 
 # t00 is a special interactive test, not normally run

--- a/tests/kern/t28
+++ b/tests/kern/t28
@@ -7,7 +7,7 @@ rsync -a /etc $PATH_MNTDIR/
 # will not report (but silently fix) an incorrect mode
 
 echo rsync /etc to mntdir again - should be silent
-rsync -avc /etc $PATH_MNTDIR/ | egrep -v '^(sent|total).*'
+rsync -avc /etc $PATH_MNTDIR/ | grep -E -v '^(sent|total).*'
 
 echo rsync /etc to expdir - should be silent
-rsync -avc /etc $PATH_EXPDIR/ | egrep -v '^(sent|total).*'
+rsync -avc /etc $PATH_EXPDIR/ | grep -E -v '^(sent|total).*'

--- a/tests/kern/t33
+++ b/tests/kern/t33
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 PATH_POSTMARK=$(pwd)/postmark/postmark
-(pushd $PATH_MNTDIR >/dev/null
+(
+cd $PATH_MNTDIR >/dev/null
 $PATH_POSTMARK <<EOT
 set size 10 100000
 set number 2000
@@ -10,5 +11,4 @@ show
 run
 quit
 EOT
-popd $PATH_MNTDIR >/dev/null
 ) >t33.postmark

--- a/tests/user/runtest
+++ b/tests/user/runtest
@@ -69,6 +69,7 @@ if [ $rc != 0 ]; then
 fi
 
 [ -d "$PATH_EXPDIR" ] && rm -rf $PATH_EXPDIR
+[ ! -f "$PATH_EXPDIR" ] || rm -f "$PATH_EXPDIR"
 
 diff $USER_SRCDIR/$TEST.exp $TEST.out >$TEST.diff
 rc=$?

--- a/tests/user/t16
+++ b/tests/user/t16
@@ -9,6 +9,7 @@ echo reading mounted file
 echo comparing result
 if ! cmp $tmpfile $PATH_EXPDIR; then
     echo results differ
+	rm -f "$tmpfile"
     exit 1
 fi
 rm -f $tmpfile


### PR DESCRIPTION
Various fixes and workarounds to make the test suite pass in Yocto Project ptest.
I've run these tests on Yocto kernel 6.6.45, which may be why `kern/t31` passes (see #103).
The tests identified in #102, #103, #105, #106 have been added to XFAIL_TESTS.