### PR TITLE
diod: do not daemonize, do not syslog

### DIFF
--- a/etc/diod.conf
+++ b/etc/diod.conf
@@ -7,7 +7,7 @@
 -- listen = { "0.0.0.0:564" }
 -- nwthreads = 16
 -- auth_required = 1
--- logdest = "syslog:daemon:err"
+-- logdest = "/var/log/diod.log"
 
 -- exports = { "ctl", "/g/g0", "/g/g10" }
 

--- a/etc/diod.service.in
+++ b/etc/diod.service.in
@@ -2,7 +2,7 @@
 Description=9P File Server
 
 [Service]
-Type=forking
+Type=exec
 ExecStart=@X_SBINDIR@/diod
 
 [Install]

--- a/man/diod.8.in
+++ b/man/diod.8.in
@@ -16,7 +16,6 @@ Some configuration can be overridden on the command line, as described below.
 .I "-f, --foreground"
 Do not change working directory to @X_LOCALSTATEDIR@/run,
 drop the controlling terminal, or run in the background.
-Send logs to stderr not syslog, unless sent somewhere else by \fI\-L\fR.
 .TP
 .I "-r, --rfdno INT"
 .TP
@@ -82,7 +81,6 @@ supplementary groups to those belonging to UID.
 .TP
 .I "-L, --logdest DEST"
 Set the destination for logging.  Possible destinations are
-\fIsyslog:facility:level\fR,
 \fIstderr\fR,
 \fIstdout\fR, or
 a file name.

--- a/man/diod.8.in
+++ b/man/diod.8.in
@@ -13,10 +13,6 @@ Configuration is read from the diod.conf (5) config file.
 Some configuration can be overridden on the command line, as described below.
 .SH OPTIONS
 .TP
-.I "-f, --foreground"
-Do not change working directory to @X_LOCALSTATEDIR@/run,
-drop the controlling terminal, or run in the background.
-.TP
 .I "-r, --rfdno INT"
 .TP
 .I "-w, --wfdno INT"

--- a/man/diod.conf.5.in
+++ b/man/diod.conf.5.in
@@ -65,8 +65,8 @@ The squash user must be present in the password file.
 .TP
 \fIlogdest = "DEST"\fR
 Set the destination for logging.
-\fIDEST\fR is in the form of \fIsyslog:facility:level\fR or \fIfilename\fR.
-The default is \fIsyslog:daemon:err\fR.
+\fIDEST\fR is \fIstdout\fR, \fIstderr\fR, or \fIfilename\fR.
+The default is \fIstderr\fR.
 .TP
 .I "statfs_passthru = 1"
 This option configures statfs to return the host file system's type

--- a/src/cmd/diod.c
+++ b/src/cmd/diod.c
@@ -14,9 +14,6 @@
 #include "config.h"
 #endif
 #include <poll.h>
-#ifndef _BSD_SOURCE
-#define _BSD_SOURCE         /* daemon () */
-#endif
 #include <stdlib.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -57,7 +54,6 @@
 
 typedef enum { SRV_FILEDES, SRV_SOCKTEST, SRV_NORMAL } srvmode_t;
 
-static void          _daemonize (void);
 static void          _setrlimit (void);
 static void          _become_user (char *name, uid_t uid, int realtoo);
 static void          _service_run (srvmode_t mode, int rfdno, int wfdno);
@@ -66,10 +62,9 @@ static void          _service_run (srvmode_t mode, int rfdno, int wfdno);
 #define NR_OPEN         1048576 /* works on RHEL 5 x86_64 arch */
 #endif
 
-static const char *options = "fr:w:d:l:t:e:Eo:u:SL:nHpc:NU:s";
+static const char *options = "r:w:d:l:t:e:Eo:u:SL:nHpc:NU:s";
 
 static const struct option longopts[] = {
-    {"foreground",         no_argument,        0, 'f'},
     {"rfdno",              required_argument,  0, 'r'},
     {"wfdno",              required_argument,  0, 'w'},
     {"debug",              required_argument,  0, 'd'},
@@ -96,7 +91,6 @@ usage()
 {
     fprintf (stderr,
 "Usage: diod [OPTIONS]\n"
-"   -f,--foreground         do not fork and disassociate with tty\n"
 "   -r,--rfdno              service connected client on read file descriptor\n"
 "   -w,--wfdno              service connected client on write file descriptor\n"
 "   -l,--listen IP:PORT     set interface to listen on (multiple -l allowed)\n"
@@ -149,9 +143,6 @@ main(int argc, char **argv)
     opterr = 0;
     while ((c = getopt_long (argc, argv, options, longopts, NULL)) != -1) {
         switch (c) {
-            case 'f':   /* --foreground */
-                diod_conf_set_foreground (1);
-                break;
             case 'r':   /* --rfdno */
                 mode = SRV_FILEDES;
                 rfdno = strtoul (optarg, NULL, 10);
@@ -337,26 +328,6 @@ _setrlimit (void)
     if (setrlimit (RLIMIT_AS, &r) < 0)
         err_exit ("setrlimit RLIMIT_AS");
 
-}
-
-/* Create run directory if it doesn't exist and chdir there.
- * Disassociate from parent's controlling tty.
- * Exit on error.
- */
-static void
-_daemonize (void)
-{
-    char rdir[PATH_MAX];
-
-    snprintf (rdir, sizeof(rdir), "%s/run/diod", X_LOCALSTATEDIR);
-    if (mkdir (rdir, 0755) < 0 && errno != EEXIST) {
-        msg ("failed to find/create %s, running out of /tmp", rdir);
-        snprintf (rdir, sizeof(rdir), "/tmp");
-    }
-    if (chdir (rdir) < 0)
-        err_exit ("chdir %s", rdir);
-    if (daemon (1, 0) < 0)
-        err_exit ("daemon");
 }
 
 /**
@@ -598,11 +569,6 @@ _service_run (srvmode_t mode, int rfdno, int wfdno)
             diod_conf_set_runasuid (euid);
         }
     }
-
-    if (!diod_conf_get_foreground () && mode != SRV_FILEDES)
-        _daemonize (); /* implicit fork - no pthreads before this */
-    if (!diod_conf_get_foreground () && mode != SRV_FILEDES)
-        diod_log_set_dest (diod_conf_get_logdest ());
 
     /* drop root */
     if (euid == 0) {

--- a/src/cmd/diod.c
+++ b/src/cmd/diod.c
@@ -111,7 +111,7 @@ usage()
 "   -u,--runas-uid UID      only allow UID to attach\n"
 "   -S,--allsquash          map all users to the squash user\n"
 "   -U,--squashuser USER    set the squash user (default nobody)\n"
-"   -L,--logdest DEST       log to DEST, can be syslog, stderr, or file\n"
+"   -L,--logdest DEST       log to DEST, can be stdout, stderr, or file\n"
 "   -d,--debug MASK         set debugging mask\n"
 "   -c,--config-file FILE   set config file path\n"
 "   -s,--socktest           run in test mode where server exits early\n"
@@ -340,7 +340,7 @@ _setrlimit (void)
 }
 
 /* Create run directory if it doesn't exist and chdir there.
- * Disassociate from parent's controlling tty.  Switch logging to syslog.
+ * Disassociate from parent's controlling tty.
  * Exit on error.
  */
 static void

--- a/src/libdiod/diod_conf.c
+++ b/src/libdiod/diod_conf.c
@@ -56,7 +56,6 @@
 /* ro_mask values to protect attribute from overwrite by config file */
 #define RO_DEBUGLEVEL           0x00000001
 #define RO_NWTHREADS            0x00000002
-#define RO_FOREGROUND           0x00000004
 #define RO_AUTH_REQUIRED        0x00000008
 #define RO_RUNASUID             0x00000010
 #define RO_USERDB               0x00000020
@@ -77,7 +76,6 @@
 typedef struct {
     int          debuglevel;
     int          nwthreads;
-    int          foreground;
     int          auth_required;
     int          hostname_lookup;
     int          statfs_passthru;
@@ -165,7 +163,6 @@ diod_conf_init (void)
 {
     config.debuglevel = DFLT_DEBUGLEVEL;
     config.nwthreads = DFLT_NWTHREADS;
-    config.foreground = DFLT_FOREGROUND;
     config.auth_required = DFLT_AUTH_REQUIRED;
     config.hostname_lookup = DFLT_HOSTNAME_LOOKUP;
     config.statfs_passthru = DFLT_STATFS_PASSTHRU;
@@ -240,16 +237,6 @@ void diod_conf_set_nwthreads (int i)
 {
     config.nwthreads = i;
     config.ro_mask |= RO_NWTHREADS;
-}
-
-/* foreground - run daemon in foreground
- */
-int diod_conf_get_foreground (void) { return config.foreground; }
-int diod_conf_opt_foreground (void) { return config.ro_mask & RO_FOREGROUND; }
-void diod_conf_set_foreground (int i)
-{
-    config.foreground = i;
-    config.ro_mask |= RO_FOREGROUND;
 }
 
 /* auth_required - whether to accept unauthenticated attaches

--- a/src/libdiod/diod_conf.h
+++ b/src/libdiod/diod_conf.h
@@ -16,7 +16,6 @@
 #define DFLT_DEBUGLEVEL         0
 #define DFLT_NWTHREADS          16
 #define DFLT_MAXMMAP            0
-#define DFLT_FOREGROUND         0
 #define DFLT_AUTH_REQUIRED      1
 #define DFLT_HOSTNAME_LOOKUP    1
 #define DFLT_STATFS_PASSTHRU    0
@@ -49,10 +48,6 @@ void    diod_conf_set_debuglevel (int i);
 int     diod_conf_get_nwthreads (void);
 int     diod_conf_opt_nwthreads (void);
 void    diod_conf_set_nwthreads (int i);
-
-int     diod_conf_get_foreground (void);
-int     diod_conf_opt_foreground (void);
-void    diod_conf_set_foreground (int i);
 
 int     diod_conf_get_auth_required (void);
 int     diod_conf_opt_auth_required (void);

--- a/src/libdiod/diod_conf.h
+++ b/src/libdiod/diod_conf.h
@@ -29,7 +29,7 @@
 #ifdef HAVE_CONFIG_FILE
 #define DFLT_CONFIGPATH     X_SYSCONFDIR "/diod.conf"
 #endif
-#define DFLT_LOGDEST            "syslog:daemon:err"
+#define DFLT_LOGDEST            "stderr"
 
 void	diod_conf_init (void);
 void	diod_conf_fini (void);

--- a/src/libdiod/diod_rdma.c
+++ b/src/libdiod/diod_rdma.c
@@ -29,7 +29,6 @@
 #include <sys/stat.h>
 #include <string.h>
 #include <stdint.h>
-#include <syslog.h>
 #include <sys/time.h>
 #include <poll.h>
 #include <pthread.h>

--- a/src/libdiod/diod_sock.c
+++ b/src/libdiod/diod_sock.c
@@ -29,7 +29,6 @@
 #include <sys/stat.h>
 #include <string.h>
 #include <stdint.h>
-#include <syslog.h>
 #include <sys/time.h>
 #include <poll.h>
 #include <pthread.h>

--- a/src/libdiod/diod_sock.c
+++ b/src/libdiod/diod_sock.c
@@ -40,11 +40,6 @@
 #include "src/libdiod/diod_log.h"
 #include "src/libdiod/diod_sock.h"
 
-extern int  hosts_ctl(char *daemon, char *name, char *addr, char *user);
-int         allow_severity = LOG_INFO;
-int         deny_severity = LOG_WARNING;
-#define DAEMON_NAME     "diod"
-
 static int
 _disable_nagle(int fd)
 {

--- a/src/libdiod/test/configfile.c
+++ b/src/libdiod/test/configfile.c
@@ -61,7 +61,6 @@ exports = {\n\
     is (s, path, "configpath is %s", path);
     ok (diod_conf_get_debuglevel () == DFLT_DEBUGLEVEL, "debuglevel is default");
     ok (diod_conf_get_nwthreads () == DFLT_NWTHREADS, "nwthreads is default");
-    ok (diod_conf_get_foreground () == DFLT_FOREGROUND, "foreground is default");
     ok (diod_conf_get_auth_required () == DFLT_AUTH_REQUIRED,
         "auth_required is default");
     ok (diod_conf_get_hostname_lookup () == DFLT_HOSTNAME_LOOKUP,
@@ -156,7 +155,6 @@ exports = { \"/g/g1\" }\n";
     is (s, path, "configpath is %s", path);
     ok (diod_conf_get_debuglevel () == DFLT_DEBUGLEVEL, "debuglevel is default");
     ok (diod_conf_get_nwthreads () == 64, "nwthreads is 64");
-    ok (diod_conf_get_foreground () == DFLT_FOREGROUND, "foreground is default");
     ok (diod_conf_get_auth_required () != 0, "auth_required is true");
     ok (diod_conf_get_hostname_lookup () == DFLT_HOSTNAME_LOOKUP,
         "hostname_lookup is default");

--- a/src/libdiod/test/configfile.c
+++ b/src/libdiod/test/configfile.c
@@ -139,7 +139,7 @@ nwthreads = 64\n\
 auth_required = 1\n\
 allsquash = 1\n\
 listen = { \"1.2.3.4:42\", \"1,2,3,5:43\" }\n\
-logdest = \"syslog:daemon:err\"\n\
+logdest = \"/tmp/diod.log\"\n\
 exportall = 1\n\
 \n\
 exports = { \"/g/g1\" }\n";
@@ -151,7 +151,7 @@ exports = { \"/g/g1\" }\n";
     diod_conf_init_config_file (path);
 
     s = diod_conf_get_logdest ();
-    is (s, "syslog:daemon:err", "logdest is syslog:daemon:err");
+    is (s, "/tmp/diod.log", "logdest is /tmp/diod.log");
     s = diod_conf_get_configpath ();
     is (s, path, "configpath is %s", path);
     ok (diod_conf_get_debuglevel () == DFLT_DEBUGLEVEL, "debuglevel is default");

--- a/tests/misc/t15
+++ b/tests/misc/t15
@@ -12,7 +12,7 @@ bg_test ()
 TEST=$(basename $0 | cut -d- -f1)
 sockfile=$(mktemp)
 bg_test $sockfile &
-${MISC_SRCDIR}/memcheck ${TOP_BUILDDIR}/src/cmd/diod -c /dev/null -n -f -e ctl -l $sockfile -s >$TEST.out 2>&1
+${MISC_SRCDIR}/memcheck ${TOP_BUILDDIR}/src/cmd/diod -c /dev/null -n -e ctl -l $sockfile -s >$TEST.out 2>&1
 diff ${MISC_SRCDIR}/$TEST.exp $TEST.out >$TEST.diff
 rm -f $sockfile
 wait %1


### PR DESCRIPTION
Since systemd (and probably other pid ones) can manage daemons running in the foreground and capture stderr, drop diod's capability to daemonize and log to syslog to keep things simple.

As a bonus it avoid the unexpected WTF? when you manually run`diod` and nothing apparently happens (because it backgrounded itself).