### PR TITLE
enable systemctl reload diod + minor logging improvements

### DIFF
--- a/etc/diod.service.in
+++ b/etc/diod.service.in
@@ -4,6 +4,7 @@ Description=9P File Server
 [Service]
 Type=exec
 ExecStart=@X_SBINDIR@/diod
+ExecReload=kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/src/cmd/diod.c
+++ b/src/cmd/diod.c
@@ -121,7 +121,7 @@ main(int argc, char **argv)
     srvmode_t mode = SRV_NORMAL;
     int rfdno = -1, wfdno = -1;
 
-    diod_log_init (argv[0]);
+    diod_log_init (NULL);
     diod_conf_init ();
 
     /* config file overrides defaults */

--- a/src/libdiod/diod_rdma.c
+++ b/src/libdiod/diod_rdma.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/signal.h>
 #include <sys/param.h>
@@ -102,6 +103,10 @@ diod_rdma_listen (diod_rdma_t rdma)
     n = rdma_listen(rdma->listen_id, 1);
     if (n)
         errn (n, "rdma_listen");
+
+    msg ("Listening on rdma %s:%d",
+         inet_ntoa (rdma->addr.sin_addr),
+         rdma_port);
 
     return 0;
 }

--- a/src/libdiod/diod_sock.c
+++ b/src/libdiod/diod_sock.c
@@ -177,6 +177,8 @@ _setup_one_inet (char *host, char *port, struct pollfd **fdsp, int *nfdsp)
             break;
         count++;
     }
+    if (count > 0)
+        msg ("Listening on %s:%s", host, port);
 done:
     if (res)
         freeaddrinfo (res);
@@ -211,6 +213,7 @@ _setup_one_unix (char *path, struct pollfd **fdsp, int *nfdsp)
     }
     if (_poll_add (fdsp, nfdsp, fd) < 0)
         goto error;
+    msg ("Listening on %s", path);
     return 1;
 error:
     if (fd != -1)

--- a/src/libtest/server.c
+++ b/src/libtest/server.c
@@ -29,7 +29,7 @@ Npsrv *test_server_create (const char *testdir, int flags, int *client_fd)
     int s[2];
     Npsrv *srv;
 
-    diod_log_init ("#"); // add TAP compatible prefix on stderr logs
+    diod_log_init ("# "); // add TAP compatible prefix on stderr logs
     diod_conf_init ();
     diod_conf_set_auth_required (0);
 

--- a/tests/misc/Makefile.am
+++ b/tests/misc/Makefile.am
@@ -8,24 +8,6 @@ TESTS_ENVIRONMENT += "TOP_BUILDDIR=$(top_builddir)"
 
 TESTS = t15
 
-CLEANFILES = *.out *.diff
+CLEANFILES = *.out *.diod
 
-AM_CFLAGS = @WARNING_CFLAGS@
-
-AM_CPPFLAGS = \
-        -I$(top_srcdir) \
-	$(LUA_INCLUDE)
-
-LDADD = $(top_builddir)/src/cmd/opt.o \
-	$(top_builddir)/src/daemon/ops.o \
-	$(top_builddir)/src/daemon/fid.o \
-	$(top_builddir)/src/daemon/exp.o \
-	$(top_builddir)/src/daemon/ioctx.o \
-	$(top_builddir)/src/daemon/xattr.o \
-	$(top_builddir)/src/libdiod/libdiod.a \
-	$(top_builddir)/src/libnpclient/libnpclient.a \
-	$(top_builddir)/src/libnpfs/libnpfs.a \
-	$(top_builddir)/src/liblsd/liblsd.a \
-	$(LIBPTHREAD) $(LUA_LIB) $(LIBMUNGE) $(LIBCAP) $(LIBTCMALLOC)
-
-EXTRA_DIST = $(TESTS) $(TESTS:%=%.exp) memcheck valgrind.supp
+EXTRA_DIST = $(TESTS) memcheck valgrind.supp

--- a/tests/misc/t15
+++ b/tests/misc/t15
@@ -12,7 +12,6 @@ bg_test ()
 TEST=$(basename $0 | cut -d- -f1)
 sockfile=$(mktemp)
 bg_test $sockfile &
-${MISC_SRCDIR}/memcheck ${TOP_BUILDDIR}/src/cmd/diod -c /dev/null -n -e ctl -l $sockfile -s >$TEST.out 2>&1
-diff ${MISC_SRCDIR}/$TEST.exp $TEST.out >$TEST.diff
+${MISC_SRCDIR}/memcheck ${TOP_BUILDDIR}/src/cmd/diod -L $TEST.diod -c /dev/null -n -e ctl -l $sockfile -s >$TEST.out 2>&1
 rm -f $sockfile
 wait %1


### PR DESCRIPTION
The systemd unit file is modified so that `systemctl reload diod` can be used to modify the exports config without completely restarting.

In addition, this tweaks logging slightly
- TAP tests log with  "# " prefix
- diod server logs without a program prefix
- listen addresses are now logged on startup