### PR TITLE
tighten up diod configuration and initialization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,10 +95,19 @@ AC_SYS_LARGEFILE
 AC_ARG_ENABLE([diodmount],
   [AS_HELP_STRING([--disable-diodmount], [do not build diodmount])])
 
-AC_ARG_ENABLE([impersonation],
-  [AS_HELP_STRING([--enable-impersonation], [allow access=user])],
-  [],
-  [enable_impersonation=auto])
+AC_ARG_ENABLE([multiuser],
+  [AS_HELP_STRING([--disable-multiuser], [build without multi-user support])])
+
+AC_ARG_WITH([ganesha-kmod],
+  [AS_HELP_STRING([--with-ganesha-kmod], [use nfs-ganesha-kmod syscalls for multi-user])])
+
+AS_IF([test "x$with_ganesha_kmod" = "xyes"], [
+  AC_DEFINE([USE_GANESHA_KMOD], [1], [Use nfs-ganesha-kmod syscalls])
+])
+
+AS_IF([test "x$enable_multiuser" != "xno"], [
+  AC_DEFINE([MULTIUSER], [1], [service files to multiple users])
+])
 
 AC_ARG_ENABLE([config],
   [AS_HELP_STRING([--disable-config], [disable lua config file support])])
@@ -114,47 +123,9 @@ AS_IF([test "x$enable_config" != "xno"], [
   AC_DEFINE([HAVE_CONFIG_FILE], [1], [lua config file support])
 ])
 
-case "${host_os}" in
-  linux*)
-    case "${enable_impersonation}" in
-      no)
-        ;;
-      yes|linux|auto)
-        enable_impersonation=linux;;
-      *)
-        AC_MSG_FAILURE([unsupported impersonation model]);;
-    esac
-    ;;
-  freebsd*)
-    case "${enable_impersonation}" in
-      no|auto)
-        enable_impersonation=no;;
-      yes|ganesha)
-        enable_impersonation=ganesha;;
-      *)
-        AC_MSG_FAILURE([unsupported impersonation model]);;
-    esac
-    ;;
-  *)
-    case "${enable_impersonation}" in
-      no|auto)
-        enable_impersonation=no;;
-      *)
-        AC_MSG_FAILURE([unsupported impersonation model]);;
-    esac
-    ;;
-esac
-
 AM_CONDITIONAL([ENABLE_DIODMOUNT], [test "x${enable_diodmount}" != "xno"])
-AM_CONDITIONAL([USE_IMPERSONATION_LINUX], [test "x${enable_impersonation}" = "xlinux"])
-AM_CONDITIONAL([USE_IMPERSONATION_GANESHA], [test "x${enable_impersonation}" = "xganesha"])
-
-if test "x${enable_impersonation}" = "xlinux"; then
-  AC_DEFINE([USE_IMPERSONATION_LINUX], [1], [Use Linux setfsuid])
-fi
-if test "x${enable_impersonation}" = "xganesha"; then
-  AC_DEFINE([USE_IMPERSONATION_GANESHA], [1], [Use nfs-ganesha-kmod syscalls])
-fi
+AM_CONDITIONAL([MULTIUSER], [test "x${enable_multiuser}" != "xno"])
+AM_CONDITIONAL([USE_GANESHA_KMOD], [test "x${with_ganesha_kmod}" = "xyes"])
 
 ##
 # Check for systemd

--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,6 @@ AC_CHECK_FUNCS( \
 )
 AC_FUNC_STRERROR_R
 X_AC_CHECK_PTHREADS
-X_AC_CHECK_COND_LIB(cap, cap_get_proc)
 X_AC_TCMALLOC
 X_AC_RDMA
 
@@ -120,6 +119,9 @@ AS_IF([test "x$enable_auth" != "xno"], [
 ])
 
 AS_IF([test "x$enable_multiuser" != "xno"], [
+  PKG_CHECK_MODULES([CAP], [libcap], [], [
+    AC_MSG_ERROR([Install libcap or configure with --disable-multiuser])
+  ])
   AC_DEFINE([MULTIUSER], [1], [service files to multiple users])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,11 @@ m4_ifndef([PKG_PROG_PKG_CONFIG],
   [AC_MSG_ERROR([PKG_PROG_PKG_CONFIG not found, please install pkgconf package before configuring.])])
 
 ##
+# Initialize pkg-config for PKG_CHECK_MODULES to avoid conditional issues
+##
+PKG_PROG_PKG_CONFIG
+
+##
 # Checks for ncurses
 ##
 PKG_CHECK_MODULES([ncurses], [ncurses])
@@ -75,7 +80,6 @@ AC_CHECK_FUNCS( \
 )
 AC_FUNC_STRERROR_R
 X_AC_CHECK_PTHREADS
-X_AC_CHECK_COND_LIB(munge, munge_ctx_create)
 X_AC_CHECK_COND_LIB(cap, cap_get_proc)
 X_AC_TCMALLOC
 X_AC_RDMA
@@ -98,11 +102,21 @@ AC_ARG_ENABLE([diodmount],
 AC_ARG_ENABLE([multiuser],
   [AS_HELP_STRING([--disable-multiuser], [build without multi-user support])])
 
+AC_ARG_ENABLE([auth],
+  [AS_HELP_STRING([--disable-auth], [build without authentication support])])
+
 AC_ARG_WITH([ganesha-kmod],
   [AS_HELP_STRING([--with-ganesha-kmod], [use nfs-ganesha-kmod syscalls for multi-user])])
 
 AS_IF([test "x$with_ganesha_kmod" = "xyes"], [
   AC_DEFINE([USE_GANESHA_KMOD], [1], [Use nfs-ganesha-kmod syscalls])
+])
+
+AS_IF([test "x$enable_auth" != "xno"], [
+  PKG_CHECK_MODULES([MUNGE], [munge], [], [
+    AC_MSG_ERROR([Install munge or configure with --disable-auth])
+  ])
+  AC_DEFINE([AUTH], [1], [Support MUNGE authentication])
 ])
 
 AS_IF([test "x$enable_multiuser" != "xno"], [

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -3,6 +3,7 @@ AM_CFLAGS = @WARNING_CFLAGS@
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	$(MUNGE_CFLAGS) \
+	$(CAP_CFLAGS) \
 	$(LUA_INCLUDE)
 AM_CPPFLAGS += $(ncurses_CPPFLAGS)
 
@@ -18,7 +19,7 @@ common_ldadd = \
 	$(top_builddir)/src/libnpfs/libnpfs.a \
 	$(top_builddir)/src/liblsd/liblsd.a \
 	$(top_builddir)/src/libdiod/libdiod.a \
-	$(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(LIBCAP) \
+	$(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(CAP_LIBS) \
 	$(LIBIBVERBS) $(LIBRDMACM) $(LIBTCMALLOC) $(ncurses_LIBS)
 
 common_sources = \

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -2,6 +2,7 @@ AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	$(MUNGE_CFLAGS) \
 	$(LUA_INCLUDE)
 AM_CPPFLAGS += $(ncurses_CPPFLAGS)
 
@@ -17,7 +18,7 @@ common_ldadd = \
 	$(top_builddir)/src/libnpfs/libnpfs.a \
 	$(top_builddir)/src/liblsd/liblsd.a \
 	$(top_builddir)/src/libdiod/libdiod.a \
-	$(LIBPTHREAD) $(LUA_LIB) $(LIBMUNGE) $(LIBCAP) \
+	$(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(LIBCAP) \
 	$(LIBIBVERBS) $(LIBRDMACM) $(LIBTCMALLOC) $(ncurses_LIBS)
 
 common_sources = \

--- a/src/cmd/diod.c
+++ b/src/cmd/diod.c
@@ -593,13 +593,16 @@ _service_run (srvmode_t mode, int rfdno, int wfdno)
                  "  Some accesses might be inappropriately denied.");
         }
 #else
-        if (init_ganesha_syscalls() < 0)
-            msg ("nfs-ganesha-kmod not loaded: changing user/group will fail");
+        if (init_ganesha_syscalls() < 0) {
+            msg_exit ("diod cannot continue in multi-user mode without"
+                      " nfs-ganesha-kmod loaded");
+        }
         /* SRV_FLAGS_SETGROUPS is ignored in user-freebsd.c */
 #endif
         msg ("Anyone can attach and access files as themselves");
 #else
-        msg ("warning: cannot change user/group (built with --disable-multiuser)");
+        msg_exit ("diod was built without multi-user support."
+                  " Run as a normal user or add --runasuser or --allsquash options.");
 #endif
     }
 

--- a/src/cmd/diod.c
+++ b/src/cmd/diod.c
@@ -231,7 +231,7 @@ main(int argc, char **argv)
         msg_exit ("--runas-uid and allsquash cannot be used together");
     if (mode == SRV_FILEDES && (rfdno == -1 || wfdno == -1))
         msg_exit ("--rfdno,wfdno must be used together");
-#ifndef HAVE_LIBMUNGE
+#ifndef AUTH
     if (diod_conf_get_auth_required ()) {
         msg_exit ("diod was built without authentication support."
                   " Run with --no-auth.");

--- a/src/cmd/diod.c
+++ b/src/cmd/diod.c
@@ -278,13 +278,8 @@ _become_user (char *name, uid_t uid)
     nsg = sizeof (sg) / sizeof(sg[0]);
     if (getgrouplist(pw->pw_name, pw->pw_gid, sg, &nsg) == -1)
         err_exit ("user %s is in too many groups", pw->pw_name);
-#if USE_IMPERSONATION_LINUX
-    if (syscall(SYS_setgroups, nsg, sg) < 0)
-        err_exit ("setgroups");
-#else
     if (setgroups (nsg, sg) < 0)
         err_exit ("setgroups");
-#endif
     if (setregid (pw->pw_gid, pw->pw_gid) < 0)
         err_exit ("setreuid");
     if (setreuid (pw->pw_uid, pw->pw_uid) < 0)

--- a/src/cmd/diod.c
+++ b/src/cmd/diod.c
@@ -231,6 +231,12 @@ main(int argc, char **argv)
         msg_exit ("--runas-uid and allsquash cannot be used together");
     if (mode == SRV_FILEDES && (rfdno == -1 || wfdno == -1))
         msg_exit ("--rfdno,wfdno must be used together");
+#ifndef HAVE_LIBMUNGE
+    if (diod_conf_get_auth_required ()) {
+        msg_exit ("diod was built without authentication support."
+                  " Run with --no-auth.");
+    }
+#endif
 
     diod_conf_validate_exports ();
 
@@ -605,6 +611,8 @@ _service_run (srvmode_t mode, int rfdno, int wfdno)
                   " Run as a normal user or add --runasuser or --allsquash options.");
 #endif
     }
+    msg ("%s authentication is required",
+         diod_conf_get_auth_required () ? "MUNGE" : "No");
 
     /* clear umask */
     umask (0);

--- a/src/libdiod/Makefile.am
+++ b/src/libdiod/Makefile.am
@@ -3,6 +3,7 @@ AM_CFLAGS = @WARNING_CFLAGS@
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	$(MUNGE_CFLAGS) \
+	$(CAP_CFLAGS) \
 	$(LUA_INCLUDE)
 
 noinst_LIBRARIES = libdiod.a
@@ -41,7 +42,7 @@ test_ldadd = \
 	$(builddir)/libdiod.a \
 	$(top_builddir)/src/libtap/libtap.a \
 	$(LUA_LIB) \
-	$(LIBCAP) \
+	$(CAP_LIBS) \
 	$(MUNGE_LIBS) \
 	$(LIBPTHREAD)
 

--- a/src/libdiod/Makefile.am
+++ b/src/libdiod/Makefile.am
@@ -2,6 +2,7 @@ AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	$(MUNGE_CFLAGS) \
 	$(LUA_INCLUDE)
 
 noinst_LIBRARIES = libdiod.a
@@ -41,7 +42,7 @@ test_ldadd = \
 	$(top_builddir)/src/libtap/libtap.a \
 	$(LUA_LIB) \
 	$(LIBCAP) \
-	$(LIBMUNGE) \
+	$(MUNGE_LIBS) \
 	$(LIBPTHREAD)
 
 TESTS = \

--- a/src/libdiod/diod_auth.c
+++ b/src/libdiod/diod_auth.c
@@ -39,8 +39,7 @@
 #include <pwd.h>
 #include <grp.h>
 #include <errno.h>
-#if HAVE_LIBMUNGE
-#define GPL_LICENSED 1
+#if AUTH
 #include <munge.h>
 #endif
 
@@ -73,7 +72,7 @@ Npauth *diod_auth_functions = &_auth;
 struct diod_auth_struct {
     int magic;
     char *datastr;
-#if HAVE_LIBMUNGE
+#if AUTH
     munge_ctx_t mungectx;
     munge_err_t mungerr;
     uid_t mungeuid;
@@ -95,7 +94,7 @@ _da_create (void)
     }
     da->magic = DIOD_AUTH_MAGIC;
     da->datastr = NULL;
-#if HAVE_LIBMUNGE
+#if AUTH
     if (!(da->mungectx = munge_ctx_create ())) {
         np_uerror (ENOMEM);
         free (da);
@@ -118,7 +117,7 @@ _da_destroy (da_t da)
     da->magic = 0;
     if (da->datastr)
         free (da->datastr);
-#if HAVE_LIBMUNGE
+#if AUTH
     if (da->mungectx)
         munge_ctx_destroy (da->mungectx);
 #endif
@@ -172,7 +171,7 @@ checkauth(Npfid *fid, Npfid *afid, char *aname)
 
     snprintf (a, sizeof(a), "checkauth(%s@%s:%s)", fid->user->uname,
               np_conn_get_client_id (fid->conn), aname ? aname : "<NULL>");
-#if HAVE_LIBMUNGE
+#if AUTH
     if (!da->datastr) {
         msg ("%s: munge cred missing", a);
         np_uerror (EPERM);
@@ -267,7 +266,7 @@ int
 diod_auth (Npcfid *afid, u32 uid)
 {
     int ret = -1;
-#if HAVE_LIBMUNGE
+#if AUTH
     char *cred = NULL;
     munge_ctx_t ctx = NULL;
 

--- a/src/libnpclient/Makefile.am
+++ b/src/libnpclient/Makefile.am
@@ -1,6 +1,7 @@
 AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
+	$(CAP_CFLAGS) \
 	-I$(top_srcdir)
 
 noinst_LIBRARIES = libnpclient.a
@@ -31,7 +32,7 @@ test_ldadd = \
 	$(top_builddir)/src/liblsd/liblsd.a \
 	$(top_builddir)/src/libtap/libtap.a \
 	$(LUA_LIB) \
-	$(LIBCAP) \
+	$(CAP_LIBS) \
 	$(LIBPTHREAD)
 
 TESTS = \

--- a/src/libnpfs/Makefile.am
+++ b/src/libnpfs/Makefile.am
@@ -1,6 +1,7 @@
 AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
+	$(CAP_CFLAGS) \
 	-I$(top_srcdir)
 
 noinst_LIBRARIES = libnpfs.a
@@ -43,15 +44,19 @@ test_ldadd = \
 	$(top_builddir)/src/liblsd/liblsd.a \
 	$(top_builddir)/src/libtest/libtest.a \
 	$(top_builddir)/src/libtap/libtap.a \
-	$(LIBCAP) \
+	$(CAP_LIBS) \
 	$(LIBPTHREAD)
 
 TESTS = \
 	test_encoding.t \
 	test_fidpool.t \
-	test_capability.t \
 	test_setfsuid.t \
 	test_setreuid.t
+
+if MULTIUSER
+TESTS += \
+	test_capability.t
+endif
 
 check_PROGRAMS = $(TESTS)
 TEST_EXTENSIONS = .t
@@ -64,8 +69,10 @@ test_encoding_t_LDADD = $(test_ldadd)
 test_fidpool_t_SOURCES = test/fidpool.c
 test_fidpool_t_LDADD = $(test_ldadd)
 
+if MULTIUSER
 test_capability_t_SOURCES = test/capability.c
 test_capability_t_LDADD = $(test_ldadd)
+endif
 
 test_setfsuid_t_SOURCES = test/setfsuid.c
 test_setfsuid_t_LDADD = $(test_ldadd)

--- a/src/libnpfs/Makefile.am
+++ b/src/libnpfs/Makefile.am
@@ -24,14 +24,14 @@ libnpfs_a_SOURCES = \
 	ctl.c \
 	xpthread.h
 
-if USE_IMPERSONATION_LINUX
-libnpfs_a_SOURCES += user-linux.c
-else
-if USE_IMPERSONATION_GANESHA
+if MULTIUSER
+if USE_GANESHA_KMOD
 libnpfs_a_SOURCES += user-freebsd.c
 else
-libnpfs_a_SOURCES += user-stub.c
+libnpfs_a_SOURCES += user-linux.c
 endif
+else
+libnpfs_a_SOURCES += user-stub.c
 endif
 
 if RDMA

--- a/src/libnpfs/test/capability.c
+++ b/src/libnpfs/test/capability.c
@@ -12,9 +12,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#if HAVE_LIBCAP
 #include <sys/capability.h>
-#endif
 #include <sys/fsuid.h>
 #include <string.h>
 
@@ -22,7 +20,6 @@
 #include "src/libtest/state.h"
 #include "src/libtap/tap.h"
 
-#if HAVE_LIBCAP
 typedef enum { S0, S1, S2, S3, S4, S5 } state_t;
 
 static void check_capability (const char *who,
@@ -156,19 +153,15 @@ static void proc0 (void)
     check_capability ("task0", "CHOWN", CAP_CHOWN, CAP_CLEAR);
 }
 
-#endif
-
 int main(int argc, char *argv[])
 {
-#if HAVE_LIBCAP
     if (geteuid () != 0 || getenv ("FAKEROOTKEY") != NULL)
         plan (SKIP_ALL, "this test must run as root");
     plan (NO_PLAN);
+
     test_state_init (S0);
     proc0 (); // spawns proc1 and proc2
-#else
-    plan (SKIP_ALL, "libcap2-dev is not installed");
-#endif
+
     done_testing ();
 
     exit (0);

--- a/src/libnpfs/user-linux.c
+++ b/src/libnpfs/user-linux.c
@@ -23,16 +23,13 @@
 #include <sys/fsuid.h>
 #include <pwd.h>
 #include <grp.h>
-#if HAVE_LIBCAP
 #include <sys/capability.h>
-#endif
 #include <sys/prctl.h>
 
 #include "npfs.h"
 #include "xpthread.h"
 #include "npfsimpl.h"
 
-#if HAVE_LIBCAP
 /* When handling requests on connections authenticated as root, we consider
  * it safe to disable DAC checks on the server and presume the client is
  * doing it.  This is only done if the server sets SRV_FLAGS_DAC_BYPASS.
@@ -79,7 +76,6 @@ done:
 	}
 	return ret;
 }
-#endif
 
 /* Note: it is possible for setfsuid/setfsgid to fail silently,
  * e.g. if user doesn't have CAP_SETUID/CAP_SETGID.
@@ -190,7 +186,6 @@ np_setfsid (Npreq *req, Npuser *u, u32 gid_override)
 			wt->fsuid = u->uid;
 		}
 	}
-#if HAVE_LIBCAP
 	if ((srv->flags & SRV_FLAGS_DAC_BYPASS) && wt->fsuid != 0) {
 		if (!wt->privcap && authuid == 0) {
 			if (_chg_privcap (srv, CAP_SET) < 0)
@@ -204,7 +199,6 @@ np_setfsid (Npreq *req, Npuser *u, u32 gid_override)
 			dumpclrd = 1;
 		}
 	}
-#endif
 	ret = 0;
 done:
 	if (dumpclrd && prctl (PR_SET_DUMPABLE, 1, 0, 0, 0) < 0)

--- a/tests/kern/Makefile.am
+++ b/tests/kern/Makefile.am
@@ -36,13 +36,14 @@ AM_CFLAGS = @WARNING_CFLAGS@
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	$(MUNGE_CFLAGS) \
+	$(CAP_CFLAGS) \
 	$(LUA_INCLUDE)
 
 
 LDADD = $(top_builddir)/src/libdiod/libdiod.a \
         $(top_builddir)/src/libnpfs/libnpfs.a \
         $(top_builddir)/src/liblsd/liblsd.a \
-        $(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(LIBCAP) $(LIBTCMALLOC)
+        $(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(CAP_LIBS) $(LIBTCMALLOC)
 
 common_sources = test.h
 

--- a/tests/kern/Makefile.am
+++ b/tests/kern/Makefile.am
@@ -35,13 +35,14 @@ AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	$(MUNGE_CFLAGS) \
 	$(LUA_INCLUDE)
 
 
 LDADD = $(top_builddir)/src/libdiod/libdiod.a \
         $(top_builddir)/src/libnpfs/libnpfs.a \
         $(top_builddir)/src/liblsd/liblsd.a \
-        $(LIBPTHREAD) $(LUA_LIB) $(LIBMUNGE) $(LIBCAP) $(LIBTCMALLOC)
+        $(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(LIBCAP) $(LIBTCMALLOC)
 
 common_sources = test.h
 

--- a/tests/user/Makefile.am
+++ b/tests/user/Makefile.am
@@ -37,6 +37,7 @@ AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	$(MUNGE_CFLAGS) \
 	$(LUA_INCLUDE)
 
 
@@ -44,7 +45,7 @@ LDADD = $(top_builddir)/src/libdiod/libdiod.a \
         $(top_builddir)/src/libnpclient/libnpclient.a \
         $(top_builddir)/src/libnpfs/libnpfs.a \
         $(top_builddir)/src/liblsd/liblsd.a \
-        $(LIBPTHREAD) $(LUA_LIB) $(LIBMUNGE) $(LIBCAP) $(LIBTCMALLOC)
+        $(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(LIBCAP) $(LIBTCMALLOC)
 
 common_sources =
 

--- a/tests/user/Makefile.am
+++ b/tests/user/Makefile.am
@@ -38,6 +38,7 @@ AM_CFLAGS = @WARNING_CFLAGS@
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	$(MUNGE_CFLAGS) \
+	$(CAP_CFLAGS) \
 	$(LUA_INCLUDE)
 
 
@@ -45,7 +46,7 @@ LDADD = $(top_builddir)/src/libdiod/libdiod.a \
         $(top_builddir)/src/libnpclient/libnpclient.a \
         $(top_builddir)/src/libnpfs/libnpfs.a \
         $(top_builddir)/src/liblsd/liblsd.a \
-        $(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(LIBCAP) $(LIBTCMALLOC)
+        $(LIBPTHREAD) $(LUA_LIB) $(MUNGE_LIBS) $(CAP_LIBS) $(LIBTCMALLOC)
 
 common_sources =
 


### PR DESCRIPTION
This tidies up the initialization code in the diod mainline and causes some of its critical choices to be logged so it's more obvious how it will be operating.   For example, `systemd status diod` shows the following on my system:
```
$ systemctl status diod
● diod.service - 9P File Server
     Loaded: loaded (/lib/systemd/system/diod.service; enabled; vendor preset: enable>
     Active: active (running) since Mon 2025-01-20 19:17:11 PST; 12min ago
   Main PID: 3914040 (diod)
      Tasks: 10 (limit: 76971)
     Memory: 664.0K
        CPU: 2ms
     CGroup: /system.slice/diod.service
             └─3914040 /usr/sbin/diod

Jan 20 19:17:11 system76-pc systemd[1]: Starting 9P File Server...
Jan 20 19:17:11 system76-pc systemd[1]: Started 9P File Server.
Jan 20 19:17:11 system76-pc diod[3914040]: Listening on 0.0.0.0:564
Jan 20 19:17:11 system76-pc diod[3914040]: Anyone can attach and access files as themselves
Jan 20 19:17:11 system76-pc diod[3914040]: MUNGE authentication is required
```

Versus when I start diod manually as a regular user:
```
$ ./diod -E -l 0.0.0.0:88888
Listening on 0.0.0.0:88888
Only garlick can attach and access files as garlick
MUNGE authentication is required
```

In addition, the handling of some `configure` outcomes was a bit loose.  For example, if munge wasn't found, authentication was silently disabled.  This fixes those issues.
