### PR TITLE
Implement Trenameat and Tunlinkat

### DIFF
--- a/src/libnpfs/fcall.c
+++ b/src/libnpfs/fcall.c
@@ -1267,7 +1267,7 @@ np_unlinkat (Npreq *req, Npfcall *tc)
 		np_uerror (95); /* v9fs expects this not ENOSYS for this op */
 		goto done;
 	}
-	rc = (*req->conn->srv->unlinkat)(dirfid, &tc->u.tunlinkat.name);
+	rc = (*req->conn->srv->unlinkat)(dirfid, &tc->u.tunlinkat.name, tc->u.tunlinkat.flags);
 done:
 	return rc;
 }

--- a/src/libnpfs/npfs.h
+++ b/src/libnpfs/npfs.h
@@ -309,7 +309,7 @@ struct Npsrv {
 	Npfcall*	(*link)(Npfid *, Npfid *, Npstr *);
 	Npfcall*	(*mkdir)(Npfid *, Npstr *, u32, u32);
 	Npfcall*	(*renameat)(Npfid *, Npstr *, Npfid *, Npstr *);
-	Npfcall*	(*unlinkat)(Npfid *, Npstr *);
+	Npfcall*	(*unlinkat)(Npfid *, Npstr *, u32);
 
 	/* implementation specific */
 	pthread_mutex_t	lock;

--- a/src/libnpfs/protocol.h
+++ b/src/libnpfs/protocol.h
@@ -164,6 +164,11 @@ enum {
 	Osync		= 04000000,
 };
 
+// flags for Tunlinkat
+enum {
+	Uremovedir	= 0x200,
+};
+
 // flags for Tlock
 enum {
 	Lblock		= 1,


### PR DESCRIPTION
Implements Tunlinkat and Trenameat, ironically not using either of those syscalls.