### PR TITLE
diod: Fix uint32 overflow when Tread/Twrite count > UINT32_MAX-IOHDRSZ

### DIFF
--- a/src/libnpfs/fcall.c
+++ b/src/libnpfs/fcall.c
@@ -413,7 +413,7 @@ np_read(Npreq *req, Npfcall *tc)
 		np_logerr (conn->srv, "read: invalid fid");
 		goto done;
 	}
-	if (tc->u.tread.count + IOHDRSZ > conn->msize) {
+	if ((u64)(tc->u.tread.count) + IOHDRSZ > conn->msize) {
 		np_uerror(EIO);
 		np_logerr (conn->srv, "read: count %u too large",
 			   tc->u.tread.count);
@@ -484,7 +484,7 @@ np_write(Npreq *req, Npfcall *tc)
 		np_uerror(EROFS);
 		goto done;
 	}
-	if (tc->u.twrite.count + IOHDRSZ > conn->msize) {
+	if ((u64)(tc->u.twrite.count) + IOHDRSZ > conn->msize) {
 		np_uerror(EIO);
 		np_logerr (conn->srv, "write: count %u too large",
 			   tc->u.twrite.count);


### PR DESCRIPTION
The check here is skipped if diod receives Tread or Twrite with a count greater than UINT32_MAX - IOHDRSZ (4294967271). This eventually trips an assert in np.c.

Let's just cast the incoming size to 64-bits before doing any math that may lead to an overflow.

I encountered this after forgetting to properly bound a read size.