### PR TITLE
diodcli: drop unused variable

### DIFF
--- a/src/cmd/diodcli.c
+++ b/src/cmd/diodcli.c
@@ -362,8 +362,8 @@ int cmd_listxattr (Npcfid *root, int argc, char **argv)
         errn (np_rerror (), "%s", filename);
         goto done;
     }
-    int i, count;
-    for (i = 0, count = 0; i < len && buf[i] != '\0'; count++) {
+    int i;
+    for (i = 0; i < len && buf[i] != '\0';) {
         char *key = &buf[i];
         int klen = len - i;
 


### PR DESCRIPTION
Problem: pre-release gcc-16 throws unused-but-set-variable error in diodcli.c

Drop unused variable.

Fixes #169

@P3p111n0 would you be able to retest with this patch?  It's a bit of a pain to set up gcc-16 at the moment since it's not yet released, so I'm not sure if more will be needed.  Thanks.