### PR TITLE
hostlist.c: fix #172: gcc15 assignment discards ‘const’ qualifier from pointer target type

### DIFF
--- a/src/liblsd/hostlist.c
+++ b/src/liblsd/hostlist.c
@@ -1409,16 +1409,16 @@ static int _parse_single_range(const char *str, struct _range *range)
 {
     char *p, *q;
     char *orig = strdup(str);
-    if (!orig) 
+    if (!orig)
         seterrno_ret(ENOMEM, 0);
 
-    if ((p = strchr(str, '-'))) {
+    if ((p = strchr(orig, '-'))) {
         *p++ = '\0';
         if (*p == '-')     /* do NOT allow negative numbers */
             goto error;
     }
-    range->lo = strtoul(str, &q, 10);
-    if (q == str) 
+    range->lo = strtoul(orig, &q, 10);
+    if (q == orig)
         goto error;
 
     range->hi = (p && *p) ? strtoul(p, &q, 10) : range->lo;
@@ -1435,8 +1435,8 @@ static int _parse_single_range(const char *str, struct _range *range)
         seterrno_ret(ERANGE, 0);
     }
 
+    range->width = strlen(orig);
     free(orig);
-    range->width = strlen(str);
     return 1;
 
   error:


### PR DESCRIPTION
duplicate fix from chaos/powerman#216